### PR TITLE
Single event generation

### DIFF
--- a/CepGen/Core/Generator.cpp
+++ b/CepGen/Core/Generator.cpp
@@ -139,12 +139,9 @@ namespace cepgen {
       mod->setCrossSection(result_, result_error_);
   }
 
-  const Event& Generator::generateOneEvent(Event::callback callback) {
-    generate(1, callback);
-    return worker_->integrand().process().event();
-  }
+  const Event& Generator::generateOneEvent(Event::callback callback) { return next(callback); }
 
-  void Generator::generate(size_t num_events, Event::callback callback) {
+  void Generator::initialise() {
     CG_TICKER(parameters_->timeKeeper());
 
     if (!parameters_)
@@ -154,6 +151,21 @@ namespace cepgen {
 
     for (auto& mod : parameters_->outputModulesSequence())
       mod->initialise(*parameters_);
+
+    initialised_ = true;
+  }
+
+  const Event& Generator::next(Event::callback callback) {
+    if (!worker_ || !initialised_)
+      initialise();
+    return worker_->next(callback);
+  }
+
+  void Generator::generate(size_t num_events, Event::callback callback) {
+    CG_TICKER(parameters_->timeKeeper());
+
+    if (!initialised_)
+      initialise();
 
     //--- if invalid argument, retrieve from runtime parameters
     if (num_events < 1) {

--- a/CepGen/Core/GeneratorWorker.h
+++ b/CepGen/Core/GeneratorWorker.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2021  Laurent Forthomme
+ *  Copyright (C) 2013-2022  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,6 +42,9 @@ namespace cepgen {
     /// \param[in] num_events Number of events to generate
     /// \param[in] callback The callback function applied on every event generated
     void generate(size_t num_events = 0, Event::callback callback = nullptr);
+    /// Generate a single event
+    /// \param[in] callback The callback function applied on every event generated
+    bool next(Event::callback callback = nullptr);
     /// Function evaluator
     ProcessIntegrand& integrand() { return *integrand_; }
 
@@ -49,9 +52,6 @@ namespace cepgen {
     /// Placeholder for invalid bin indexing
     static constexpr int UNASSIGNED_BIN = -999;
 
-    /// Generate a single event
-    /// \param[in] callback The callback function applied on every event generated
-    bool next(Event::callback callback = nullptr);
     /// Store the event in the output file
     /// \param[in] callback The callback function for every event generated
     /// \return A boolean stating whether or not the event was successfully saved

--- a/CepGen/Generator.h
+++ b/CepGen/Generator.h
@@ -25,14 +25,14 @@
 /**
  * \mainpage Foreword
  * This Monte Carlo generator was developed as a modern version of the LPAIR code introduced
- * in the early 1990s by J. Vermaseren *et al*\cite Baranov:1991yq\cite Vermaseren:1982cz. This latter allows to
- * compute the cross-section and to generate events for the \f$\gamma\gamma\to\ell^{+}\ell^{-}\f$
- * process in the scope of high energy physics.
+ * in the early 1990s by J. Vermaseren *et al*\cite Baranov:1991yq\cite Vermaseren:1982cz. This
+ * latter allows to compute the cross-section and to generate events for the
+ * \f$\gamma\gamma\to\ell^{+}\ell^{-}\f$ process for ee, ep, and pp collisions.
  *
  * Soon after the integration of its matrix element, it was extended as a tool to compute and
  * generate events for any generic 2\f$\rightarrow\f$ 3 central exclusive process.
- * To do so, the main operation performed here is the integration of the matrix element (given as a
- * subset of a Process object) over the full available phase space.
+ * To do so, the main operation performed here is the integration of the matrix element (given
+ * as a subset of a Process object) over the full available phase space.
  *
  */
 
@@ -120,14 +120,14 @@ namespace cepgen {
     /// Last error on the cross section computed by the generator
     double crossSectionError() const { return result_error_; }
 
-    //void terminate();
+    // void terminate();
     /// \deprecated Replaced by the generic method \a generate.
-    [[deprecated("Please use generate instead")]] const Event& generateOneEvent(Event::callback callback = nullptr);
+    [[deprecated("Please use generate or next instead")]] const Event& generateOneEvent(Event::callback = nullptr);
     /// Launch the generation of events
     void generate(size_t num_events = 0, Event::callback = nullptr);
     /// Generate one event
     /// \param[in] callback Callback function where the generated event can be fed
-    const Event& next(Event::callaback callback = nullptr);
+    const Event& next(Event::callback callback = nullptr);
     /// Compute one single point from the total phase space
     /// \param[in] x the n-dimensional point to compute
     /// \return the function value for the given point

--- a/CepGen/Generator.h
+++ b/CepGen/Generator.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2021  Laurent Forthomme
+ *  Copyright (C) 2013-2022  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -124,19 +124,26 @@ namespace cepgen {
     /// \deprecated Replaced by the generic method \a generate.
     [[deprecated("Please use generate instead")]] const Event& generateOneEvent(Event::callback callback = nullptr);
     /// Launch the generation of events
-    void generate(size_t num_events = 0, Event::callback callback = nullptr);
+    void generate(size_t num_events = 0, Event::callback = nullptr);
+    /// Generate one event
+    /// \param[in] callback Callback function where the generated event can be fed
+    const Event& next(Event::callaback callback = nullptr);
     /// Compute one single point from the total phase space
     /// \param[in] x the n-dimensional point to compute
     /// \return the function value for the given point
     double computePoint(const std::vector<double>& x);
 
   private:
+    /// Initialise the generation of events
+    void initialise();
     /// Physical Parameters used in the events generation and cross-section computation
     std::unique_ptr<Parameters> parameters_;
     /// Generator worker instance
     std::unique_ptr<GeneratorWorker> worker_;
     /// Integration algorithm
     std::unique_ptr<Integrator> integrator_;
+    /// Has the event generator already been initialised?
+    bool initialised_{false};
     /// Cross section value computed at the last integration
     double result_{-1.};
     /// Error on the cross section as computed in the last integration

--- a/test/generate_events.cc
+++ b/test/generate_events.cc
@@ -1,0 +1,41 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2022  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Cards/Handler.h"
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Generator.h"
+#include "CepGen/Utils/ArgumentsParser.h"
+
+using namespace std;
+
+int main(int argc, char* argv[]) {
+  string input_card;
+  int num_events;
+
+  cepgen::ArgumentsParser(argc, argv)
+      .addOptionalArgument("config,i", "path to the configuration file", &input_card, "Cards/lpair_cfg.py")
+      .addOptionalArgument("num-events,n", "number of events to generate", &num_events, 10)
+      .parse();
+
+  cepgen::Generator gen;
+  gen.setParameters(cepgen::card::Handler::parse(input_card));
+  for (auto iev = 0; iev < num_events; ++iev)
+    gen.next().dump();
+
+  return 0;
+}


### PR DESCRIPTION
This PR eases the `cepgen::Generator` API to generate (and retrieve) a single event after a successful configuration.