### PR TITLE
Exposing structure functions to python

### DIFF
--- a/CepGenAddOns/BoostWrapper/CMakeLists.txt
+++ b/CepGenAddOns/BoostWrapper/CMakeLists.txt
@@ -1,10 +1,7 @@
 find_package(Boost)
-
 if(NOT Boost_FOUND)
   return()
 endif()
-
-include_directories(${PROJECT_SOURCE_DIR})
 
 set(sources BoostTreeHandler.cpp
             BoostTreeUtils.cpp
@@ -31,3 +28,27 @@ cpack_add_component(boost
     DISPLAY_NAME "CepGen Boost wrappers library"
     DESCRIPTION "Collection of CepGen wrappers to the Boost library"
     DEPENDS lib)
+
+#----- Python bindings
+
+find_package(Boost COMPONENTS system python)
+find_package(PythonLibs)
+if(NOT Boost_FOUND OR NOT PYTHONLIBS_FOUND)
+  return()
+endif()
+
+add_library(pycepgen SHARED PythonWrapper.cpp)
+target_link_libraries(pycepgen CepGen ${Boost_LIBRARIES})
+target_include_directories(pycepgen PUBLIC ${PYTHON_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+configure_file(__init__.py ${CMAKE_CURRENT_BINARY_DIR}/src/__init__.py COPYONLY)
+set_target_properties(pycepgen PROPERTIES PREFIX "")
+find_package(Python COMPONENTS Interpreter Development)
+if(NOT Python_FOUND)
+  execute_process(COMMAND "${Python_EXECUTABLE}" -c "if True:
+      from distutils import sysconfig as sc
+      print(sc.get_python_lib('platlib'))"
+    OUTPUT_VARIABLE Python_SITEARCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+install(TARGETS pycepgen DESTINATION "${Python_SITEARCH}" COMPONENT boost)
+#install(TARGETS pycepgen __init__.py DESTINATION "${Python_SITEARCH}" COMPONENT boost)

--- a/CepGenAddOns/BoostWrapper/PythonWrapper.cpp
+++ b/CepGenAddOns/BoostWrapper/PythonWrapper.cpp
@@ -1,0 +1,58 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/mpl/vector.hpp>
+#include <boost/python.hpp>
+
+#include "CepGen/Generator.h"
+#include "CepGen/Modules/StructureFunctionsFactory.h"
+#include "CepGen/StructureFunctions/Parameterisation.h"
+
+namespace {
+  namespace py = boost::python;
+
+  template <typename T, typename... Args>
+  py::object adapt_unique(std::unique_ptr<T> (*fn)(Args...)) {
+    return py::make_function([fn](Args... args) { return fn(args...).release(); },
+                             py::return_value_policy<py::manage_new_object>(),
+                             boost::mpl::vector<T*, Args...>());
+  }
+
+  template <typename T, typename C, typename... Args>
+  py::object adapt_unique(std::unique_ptr<T> (C::*fn)(Args...)) {
+    return py::make_function([fn](C& self, Args... args) { return (self.*fn)(args...).release(); },
+                             py::return_value_policy<py::manage_new_object>(),
+                             boost::mpl::vector<T*, C&, Args...>());
+  }
+
+  BOOST_PYTHON_MODULE(pycepgen) {
+    cepgen::initialise();
+
+    py::class_<cepgen::strfun::Parameterisation, boost::noncopyable>("StructureFunctions",
+                                                                     py::init<cepgen::ParametersList>())
+        .def("F2", &cepgen::strfun::Parameterisation::F2)
+        .def("FL", &cepgen::strfun::Parameterisation::FL)
+        .def("F1", &cepgen::strfun::Parameterisation::F1);
+
+    py::class_<cepgen::StructureFunctionsFactory, boost::noncopyable>("StructureFunctionsFactory", py::no_init)
+        .def("build", adapt_unique(+[](int mod) { return cepgen::StructureFunctionsFactory::get().build(mod); }))
+        .def("build", adapt_unique(+[](const cepgen::ParametersList& plist) {
+               return cepgen::StructureFunctionsFactory::get().build(plist);
+             }));
+  }
+}  // namespace

--- a/CepGenAddOns/BoostWrapper/__init__.py
+++ b/CepGenAddOns/BoostWrapper/__init__.py
@@ -1,0 +1,1 @@
+from .pycepgen import *


### PR DESCRIPTION
This is a first skeletton of a python interface to CepGen.
It allows to expose the structure functions builder to an external python code through e.g. a snippet like:

```python
import pycepgen

sf_luxlike = pycepgen.StructureFunctionsFactory.build(301)
print(sf_luxlike.F2(0.5, 100.))

```