### PR TITLE
Integration: added Python Vegas wrapper

### DIFF
--- a/CepGenAddOns/PythonWrapper/CMakeLists.txt
+++ b/CepGenAddOns/PythonWrapper/CMakeLists.txt
@@ -22,12 +22,20 @@ else()
   list(APPEND Python_LIBRARIES ${PYTHON_LIBRARIES})
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR})
+file(GLOB sources *.cpp)
+
+execute_process(COMMAND pip show vegas RESULT_VARIABLE VEGAS_RES OUTPUT_QUIET)
+if(${VEGAS_RES} EQUAL 0)
+  message(STATUS "-- Vegas python package present")
+else()
+  file(GLOB vegas IntegratorVegasPlus.cpp)
+  list(REMOVE_ITEM sources ${vegas})
+endif()
 
 #----- build the object
 
 enable_testing()
-cepgen_build(CepGenPython SOURCES *.cpp
+cepgen_build(CepGenPython SOURCES ${sources}
     TESTS test/*.cc
     EXT_LIBS ${Python_LIBRARIES}
     EXT_HEADERS ${Python_INCLUDE_DIRS}

--- a/CepGenAddOns/PythonWrapper/IntegratorVegasPlus.cpp
+++ b/CepGenAddOns/PythonWrapper/IntegratorVegasPlus.cpp
@@ -1,0 +1,96 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Integration/Integrand.h"
+#include "CepGen/Integration/Integrator.h"
+#include "CepGen/Modules/IntegratorFactory.h"
+#include "CepGen/Utils/String.h"
+#include "CepGenAddOns/PythonWrapper/Environment.h"
+#include "CepGenAddOns/PythonWrapper/Error.h"
+#include "CepGenAddOns/PythonWrapper/PythonUtils.h"
+
+namespace cepgen {
+  class IntegratorVegasPlus final : public Integrator {
+  public:
+    explicit IntegratorVegasPlus(const ParametersList& params) : Integrator(params) {
+      env_.setProgramName("vegas_plus");
+      const auto str = R"(
+import vegas
+def integrate(f, num_dim: int, num_iter: int, num_warmup: int, num_calls: int):
+    integ = vegas.Integrator(num_dim * [(0., 1.)])
+    def f_pyarr(vars):
+        return f(vars.tolist())
+    integ(f_pyarr, nitn=num_iter, neval=num_warmup)
+    res = integ(f_pyarr, nitn=num_iter, neval=num_calls)
+    return (res.mean, res.sdev)
+      )";
+      auto cfg = python::defineModule("vegas_plus", str);  // new
+      if (!cfg)
+        throw PY_ERROR << "Failed to parse a configuration string:\n"
+                       << std::string(80, '-') << "\n"
+                       << str << "\n"
+                       << std::string(80, '-');
+      func_ = python::getAttribute(cfg.get(), "integrate");
+      if (!func_ || !PyCallable_Check(func_.get()))
+        throw PY_ERROR << "Failed to retrieve/cast the object to a Python functional.";
+    }
+
+    void integrate(Integrand& integrand, double& result, double& abs_error) override {
+      gIntegrand = &integrand;
+      const auto iterations = steer<int>("iterations");
+      const auto evals = steer<int>("evals");
+      PyMethodDef py_integr = {"integrand", py_integrand, METH_VARARGS, "A python-wrapped integrand"};
+      python::ObjectPtr function(PyCFunction_NewEx(&py_integr, nullptr, python::set<std::string>("integrand").get()));
+      python::ObjectPtr value(PyObject_CallObject(
+          func_.get(),
+          python::newTuple(std::make_tuple(function.get(), (int)integrand.size(), iterations, 1000, evals))
+              .release()));  // new
+      if (!value)
+        throw PY_ERROR;
+      const auto vals = python::getVector<double>(value);
+      if (vals.size() < 2)
+        throw CG_FATAL("IntegratorVegasPlus")
+            << "Wrong multiplicity of result returned from Python's Vegas: " << vals << ".";
+      result_ = result = vals[0];
+      err_result_ = abs_error = vals[1];
+    }
+
+    static ParametersDescription description() {
+      auto desc = Integrator::description();
+      desc.setDescription("Vegas+ MC integrator");
+      desc.add<int>("iterations", 10);
+      desc.add<int>("evals", 1000);
+      return desc;
+    }
+    static Integrand* gIntegrand;
+
+  private:
+    python::Environment env_;
+    python::ObjectPtr func_;
+    static PyObject* py_integrand(PyObject* /*self*/, PyObject* args) {
+      if (!gIntegrand)
+        throw CG_FATAL("IntegratorVegasPlus") << "Integrand was not initialised.";
+      const auto c_args = python::getVector<double>(PyTuple_GetItem(args, 0));
+      return python::set<double>(gIntegrand->eval(c_args)).release();
+    }
+  };
+  Integrand* IntegratorVegasPlus::gIntegrand = nullptr;
+}  // namespace cepgen
+
+REGISTER_INTEGRATOR("vegas_plus", IntegratorVegasPlus);

--- a/CepGenAddOns/PythonWrapper/PythonTypes.cpp
+++ b/CepGenAddOns/PythonWrapper/PythonTypes.cpp
@@ -250,9 +250,9 @@ namespace cepgen {
       if (!pfirst)
         return false;
       if (!is<T>(pfirst)) {  // only allow same-type tuples/lists
-        CG_WARNING("Python::isVector") << "Wrong object type unpacked from tuple/list: (python)"
-                                       << pfirst->ob_type->tp_name << " != (c++)" << utils::demangle(typeid(T).name())
-                                       << ".";
+        CG_DEBUG("Python::isVector") << "Wrong object type unpacked from tuple/list: (python)"
+                                     << pfirst->ob_type->tp_name << " != (c++)" << utils::demangle(typeid(T).name())
+                                     << ".";
         return false;
       }
       return true;


### PR DESCRIPTION
This PR adds the capability to launch a Monte Carlo multidimensional integration through [the Python implementation](https://github.com/gplepage/vegas) of the [Vegas algorithm](https://doi.org/10.1016/0021-9991(78)90004-9) (including the [enhanced Vegas+ algorithm](https://arxiv.org/abs/2009.05112)).