### PR TITLE
Value with uncertainty object

### DIFF
--- a/CepGen/Core/Generator.cpp
+++ b/CepGen/Core/Generator.cpp
@@ -142,9 +142,7 @@ namespace cepgen {
     if (!integrator_)
       throw CG_FATAL("Generator:integrate") << "No integrator object was declared for the generator!";
 
-    double result, result_error;
-    integrator_->integrate(worker_->integrand(), result, result_error);
-    xsect_ = Value{result, result_error};
+    xsect_ = integrator_->integrate(worker_->integrand());
 
     CG_DEBUG("Generator:integrate") << "Computed cross section: (" << xsect_ << ") pb.";
 

--- a/CepGen/Core/Generator.cpp
+++ b/CepGen/Core/Generator.cpp
@@ -87,7 +87,7 @@ namespace cepgen {
 
   void Generator::computeXsection(double& cross_section, double& err) {
     const auto xsec = computeXsection();
-    cross_section = (double)xsec;
+    cross_section = xsec;
     err = xsec.uncertainty();
   }
 
@@ -96,9 +96,9 @@ namespace cepgen {
 
     integrate();  // run is cleared here
 
-    if ((double)xsect_ < 1.e-2)
+    if (xsect_ < 1.e-2)
       CG_INFO("Generator") << "Total cross section: " << xsect_ * 1.e3 << " fb.";
-    else if ((double)xsect_ < 0.5e3)
+    else if (xsect_ < 0.5e3)
       CG_INFO("Generator") << "Total cross section: " << xsect_ << " pb.";
     else if (xsect_ < 0.5e6)
       CG_INFO("Generator") << "Total cross section: " << xsect_ * 1.e-3 << " nb.";
@@ -193,7 +193,7 @@ namespace cepgen {
     //--- if invalid argument, retrieve from runtime parameters
     if (num_events < 1) {
       if (parameters_->generation().targetLuminosity() > 0.) {
-        num_events = std::ceil(parameters_->generation().targetLuminosity() * (double)xsect_);
+        num_events = std::ceil(parameters_->generation().targetLuminosity() * xsect_);
         CG_INFO("Generator") << "Target luminosity: " << parameters_->generation().targetLuminosity() << " pb-1.";
       } else
         num_events = parameters_->generation().maxGen();

--- a/CepGen/EventFilter/EventExporter.h
+++ b/CepGen/EventFilter/EventExporter.h
@@ -25,6 +25,7 @@
 
 namespace cepgen {
   class Event;
+  class Value;
   /**
    * \brief Output format handler for events export
    * \author Laurent Forthomme <laurent.forthomme@cern.ch>
@@ -34,8 +35,8 @@ namespace cepgen {
   public:
     explicit EventExporter(const ParametersList&);
 
-    /// Set the process cross section and its associated error
-    virtual void setCrossSection(double /*cross_section*/, double /*err_cross_section*/) {}
+    /// Specify the process cross section and uncertainty, in pb
+    virtual void setCrossSection(const Value&) {}
     /// Set the event number
     void setEventNumber(unsigned long long ev_id) { event_num_ = ev_id; }
 
@@ -51,4 +52,3 @@ namespace cepgen {
 }  // namespace cepgen
 
 #endif
-

--- a/CepGen/EventFilter/EventHarvester.cpp
+++ b/CepGen/EventFilter/EventHarvester.cpp
@@ -97,7 +97,7 @@ namespace cepgen {
     if (!show_hists_ && !save_hists_)
       return;
     for (auto& h_var : hists_) {
-      h_var.hist.scale((double)cross_section_ / (num_evts_ + 1));
+      h_var.hist.scale(cross_section_ / (num_evts_ + 1));
       h_var.hist.setTitle(proc_name_);
       std::ostringstream os;
       if (drawer_)

--- a/CepGen/EventFilter/EventHarvester.cpp
+++ b/CepGen/EventFilter/EventHarvester.cpp
@@ -97,7 +97,7 @@ namespace cepgen {
     if (!show_hists_ && !save_hists_)
       return;
     for (auto& h_var : hists_) {
-      h_var.hist.scale(cross_section_ / (num_evts_ + 1));
+      h_var.hist.scale((double)cross_section_ / (num_evts_ + 1));
       h_var.hist.setTitle(proc_name_);
       std::ostringstream os;
       if (drawer_)

--- a/CepGen/EventFilter/EventHarvester.h
+++ b/CepGen/EventFilter/EventHarvester.h
@@ -20,6 +20,7 @@
 
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/Utils/Histogram.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   class Event;
@@ -40,7 +41,7 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override;
-    void setCrossSection(double cross_section, double) override { cross_section_ = cross_section; }
+    void setCrossSection(const Value& cross_section) override { cross_section_ = cross_section; }
     void operator<<(const Event&) override;
 
   private:
@@ -52,7 +53,7 @@ namespace cepgen {
     std::ofstream file_;
     std::unique_ptr<utils::Drawer> drawer_;
 
-    double cross_section_{1.};
+    Value cross_section_{1., 0.};
     unsigned long num_evts_{0ul};
 
     /// Name of the physics process
@@ -76,4 +77,3 @@ namespace cepgen {
     std::vector<Hist2DInfo> hists2d_;
   };
 }  // namespace cepgen
-

--- a/CepGen/EventFilter/EventModifier.h
+++ b/CepGen/EventFilter/EventModifier.h
@@ -25,6 +25,7 @@
 #include "CepGen/EventFilter/EventHandler.h"
 
 namespace cepgen {
+  class Value;
   /// Class template to interface (external/internal) events modification algorithms
   /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
   /// \date July 2019
@@ -55,7 +56,7 @@ namespace cepgen {
        */
     virtual bool run(Event& ev, double& weight, bool full = true) = 0;
     /// Specify the process cross section and uncertainty, in pb
-    virtual void setCrossSection(double, double) {}
+    virtual void setCrossSection(const Value&) {}
 
   protected:
     /// Random numbers generator seed fed to the algorithm

--- a/CepGen/Generator.h
+++ b/CepGen/Generator.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2022  Laurent Forthomme
+ *  Copyright (C) 2013-2023  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "CepGen/Event/Event.h"
+#include "CepGen/Utils/Value.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -112,18 +113,17 @@ namespace cepgen {
     void clearRun();
     /// Integrate the functional over the whole phase space
     void integrate();
-    /**
-       * Compute the cross section for the run parameters defined by this object.
-       * This returns the cross section as well as the absolute error computed along.
-       * \brief Compute the cross-section for the given process
-       * \param[out] xsec The computed cross-section, in pb
-       * \param[out] err The absolute integration error on the computed cross-section, in pb
-       */
-    void computeXsection(double& cross_section, double& err);
+    /// Compute the cross section for the run parameters
+    /// \return The computed cross-section and uncertainty, in pb
+    Value computeXsection();
+    /// Compute the cross section for the run parameters
+    /// \param[out] xsec The computed cross-section, in pb
+    /// \param[out] err The absolute integration error on the computed cross-section, in pb
+    [[deprecated("Please use the parameters-less version")]] void computeXsection(double& cross_section, double& err);
     /// Last cross section computed by the generator
-    double crossSection() const { return result_; }
+    double crossSection() const { return xsect_; }
     /// Last error on the cross section computed by the generator
-    double crossSectionError() const { return result_error_; }
+    double crossSectionError() const { return xsect_.uncertainty(); }
 
     // void terminate();
     /// \deprecated Replaced by the generic method \a generate.
@@ -152,9 +152,7 @@ namespace cepgen {
     /// Has the event generator already been initialised?
     bool initialised_{false};
     /// Cross section value computed at the last integration
-    double result_{-1.};
-    /// Error on the cross section as computed in the last integration
-    double result_error_{-1.};
+    Value xsect_{-1., -1.};
   };
 }  // namespace cepgen
 

--- a/CepGen/Integration/Integrator.cpp
+++ b/CepGen/Integration/Integrator.cpp
@@ -53,23 +53,21 @@ namespace cepgen {
 
   double Integrator::uniform(double min, double max) const { return min + (max - min) * rnd_(rnd_gen_); }
 
-  double Integrator::integrate(Integrand& integrand) {
+  Value Integrator::integrate(Integrand& integrand) {
     if (limits_.size() != integrand.size())
       limits_ = std::vector<Limits>(integrand.size(), Limits{0., 1.});
-    double result, tmp;
-    integrate(integrand, result, tmp);
-    return result;
+    return integrate(integrand);
   }
 
-  double Integrator::integrate(const std::function<double(const std::vector<double>&)>& func,
-                               const ParametersList& params,
-                               size_t num_vars) {
+  Value Integrator::integrate(const std::function<double(const std::vector<double>&)>& func,
+                              const ParametersList& params,
+                              size_t num_vars) {
     return integrate(func, params, std::vector<Limits>(num_vars, Limits{0., 1.}));
   }
 
-  double Integrator::integrate(const std::function<double(const std::vector<double>&)>& func,
-                               const ParametersList& params,
-                               const std::vector<Limits>& limits) {
+  Value Integrator::integrate(const std::function<double(const std::vector<double>&)>& func,
+                              const ParametersList& params,
+                              const std::vector<Limits>& limits) {
     auto integr = IntegratorFactory::get().build(params);
     integr->setLimits(limits);
     auto integrand = FunctionIntegrand(limits.size(), func);

--- a/CepGen/Integration/Integrator.h
+++ b/CepGen/Integration/Integrator.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "CepGen/Modules/NamedModule.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   class Integrand;
@@ -46,24 +47,18 @@ namespace cepgen {
 
     /// Perform the multidimensional Monte Carlo integration
     /// \param[out] result integral computed over the full phase space
-    /// \param[out] abserr uncertainty associated to the computed integral
-    virtual void integrate(Integrand&, double& result, double& abserr) = 0;
-    /// Perform an integration with no use of the numerical error
-    /// \return the integral computed over the full phase space
-    double integrate(Integrand&);
+    virtual Value integrate(Integrand& result) = 0;
     /// Perform an integration with a given functional and a given set of parameters
-    static double integrate(const std::function<double(const std::vector<double>&)>&, const ParametersList&, size_t);
+    static Value integrate(const std::function<double(const std::vector<double>&)>&, const ParametersList&, size_t);
     /// Perform an integration with a given functional and a given set of parameters
-    static double integrate(const std::function<double(const std::vector<double>&)>&,
-                            const ParametersList&,
-                            const std::vector<Limits>&);
+    static Value integrate(const std::function<double(const std::vector<double>&)>&,
+                           const ParametersList&,
+                           const std::vector<Limits>&);
 
   protected:
     const unsigned long seed_;    ///< Random number generator seed
     int verbosity_;               ///< Integrator verbosity
     std::vector<Limits> limits_;  ///< List of per-variable integration limits
-    double result_{0.};           ///< Result of the last integration
-    double err_result_{0.};       ///< Standard deviation for the last integration
     mutable std::default_random_engine rnd_gen_;
     mutable std::uniform_real_distribution<double> rnd_;
   };

--- a/CepGen/Integration/IntegratorMISER.cpp
+++ b/CepGen/Integration/IntegratorMISER.cpp
@@ -30,7 +30,7 @@ namespace cepgen {
 
     static ParametersDescription description();
 
-    void integrate(Integrand&, double&, double&) override;
+    Value integrate(Integrand&) override;
 
   private:
     int ncvg_;
@@ -45,7 +45,7 @@ namespace cepgen {
   IntegratorMISER::IntegratorMISER(const ParametersList& params)
       : IntegratorGSL(params), ncvg_(steer<int>("numFunctionCalls")) {}
 
-  void IntegratorMISER::integrate(Integrand& integrand, double& result, double& abserr) {
+  Value IntegratorMISER::integrate(Integrand& integrand) {
     setIntegrand(integrand);
     miser_state_.reset(gsl_monte_miser_alloc(function_->dim));
     miser_state_->verbose = verbosity_;
@@ -65,6 +65,7 @@ namespace cepgen {
                                  << "Dither: " << miser_params_.dither << ".";
 
     // launch the full integration
+    double result, abserr;
     int res = gsl_monte_miser_integrate(function_.get(),
                                         &xlow_[0],
                                         &xhigh_[0],
@@ -79,8 +80,7 @@ namespace cepgen {
       throw CG_FATAL("Integrator:integrate") << "Error while performing the integration!\n\t"
                                              << "GSL error: " << gsl_strerror(res) << ".";
 
-    result_ = result;
-    err_result_ = abserr;
+    return Value{result, abserr};
   }
 
   ParametersDescription IntegratorMISER::description() {

--- a/CepGen/Integration/IntegratorPlain.cpp
+++ b/CepGen/Integration/IntegratorPlain.cpp
@@ -30,7 +30,7 @@ namespace cepgen {
 
     static ParametersDescription description();
 
-    void integrate(Integrand&, double& result, double& abserr) override;
+    Value integrate(Integrand&) override;
 
   private:
     const int ncvg_;
@@ -39,12 +39,13 @@ namespace cepgen {
   IntegratorPlain::IntegratorPlain(const ParametersList& params)
       : IntegratorGSL(params), ncvg_(steer<int>("numFunctionCalls")) {}
 
-  void IntegratorPlain::integrate(Integrand& integrand, double& result, double& abserr) {
+  Value IntegratorPlain::integrate(Integrand& integrand) {
     setIntegrand(integrand);
 
     //--- launch integration
     std::unique_ptr<gsl_monte_plain_state, void (*)(gsl_monte_plain_state*)> pln_state(
         gsl_monte_plain_alloc(function_->dim), gsl_monte_plain_free);
+    double result, abserr;
     int res = gsl_monte_plain_integrate(function_.get(),
                                         &xlow_[0],
                                         &xhigh_[0],
@@ -59,8 +60,7 @@ namespace cepgen {
       throw CG_FATAL("Integrator:integrate") << "Error while performing the integration!\n\t"
                                              << "GSL error: " << gsl_strerror(res) << ".";
 
-    result_ = result;
-    err_result_ = abserr;
+    return Value{result, abserr};
   }
 
   ParametersDescription IntegratorPlain::description() {

--- a/CepGen/Integration/IntegratorVegas.cpp
+++ b/CepGen/Integration/IntegratorVegas.cpp
@@ -32,7 +32,7 @@ namespace cepgen {
 
     static ParametersDescription description();
 
-    void integrate(Integrand&, double&, double&) override;
+    Value integrate(Integrand&) override;
 
     enum class Mode { importance = 1, importanceOnly = 0, stratified = -1 };
 
@@ -68,7 +68,7 @@ namespace cepgen {
     verbosity_ = steer<int>("verbose");  // supersede the parent default verbosity level
   }
 
-  void IntegratorVegas::integrate(Integrand& integrand, double& result, double& abserr) {
+  Value IntegratorVegas::integrate(Integrand& integrand) {
     setIntegrand(integrand);
 
     //--- start by preparing the grid/state
@@ -106,6 +106,7 @@ namespace cepgen {
 
     // integration phase
     unsigned short it_chisq = 0;
+    double result, abserr;
     do {
       int res = gsl_monte_vegas_integrate(function_.get(),
                                           &xlow_[0],
@@ -133,8 +134,7 @@ namespace cepgen {
                                      << "and generated " << vegas_state_->bins_max << " bins.\n\t"
                                      << "Integration volume: " << vegas_state_->vol << ".";
 
-    result_ = result;
-    err_result_ = abserr;
+    return Value{result, abserr};
   }
 
   void IntegratorVegas::warmup(size_t ncall) {

--- a/CepGen/OutputModules/TextEventHandler.cpp
+++ b/CepGen/OutputModules/TextEventHandler.cpp
@@ -22,6 +22,7 @@
 #include "CepGen/Event/Event.h"
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/Modules/EventExporterFactory.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   /// Simple event dump module
@@ -35,7 +36,7 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override;
-    void setCrossSection(double, double) override;
+    void setCrossSection(const Value&) override;
     void operator<<(const Event&) override;
 
   private:
@@ -63,9 +64,9 @@ namespace cepgen {
       *out_ << banner("#") << "\n";
   }
 
-  void TextEventHandler::setCrossSection(double cross_section, double cross_section_err) {
+  void TextEventHandler::setCrossSection(const Value& cross_section) {
     if (out_ != &std::cout)
-      *out_ << "Total cross-section: " << cross_section << " +/- " << cross_section_err << " pb.\n";
+      *out_ << "Total cross-section: " << cross_section << " pb.\n";
   }
 
   void TextEventHandler::operator<<(const Event& ev) {

--- a/CepGen/OutputModules/TextVariablesHandler.cpp
+++ b/CepGen/OutputModules/TextVariablesHandler.cpp
@@ -37,7 +37,6 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override;
-    void setCrossSection(double, double) override {}
     void operator<<(const Event&) override;
 
   private:

--- a/CepGen/Utils/Drawable.h
+++ b/CepGen/Utils/Drawable.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "CepGen/Utils/Limits.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   namespace utils {
@@ -89,19 +90,12 @@ namespace cepgen {
         double value_unc = 0.;   ///< Bin uncertainty
         std::string label = "";  ///< Human-readable description of the bin
       };
-      /// Helper view of a pair of bin value and its uncertainty
-      struct value_t {
-        /// Sorting helper for bin values
-        bool operator<(const value_t& oth) const { return value < oth.value; }
-        double value{0.};       ///< Single bin content
-        double value_unc = 0.;  ///< Uncertainty on bin content
-      };
       /// Metadata for an axis (coordinates and bins value)
-      typedef std::map<coord_t, value_t> axis_t;
+      typedef std::map<coord_t, Value> axis_t;
       /// Comparator of an axis by the values it holds
       struct CompareAxisByValue {
-        bool operator()(const std::pair<coord_t, value_t>& lhs, const std::pair<coord_t, value_t>& rhs) {
-          return lhs.second.value < rhs.second.value;
+        bool operator()(const std::pair<coord_t, Value>& lhs, const std::pair<coord_t, Value>& rhs) {
+          return lhs.second < rhs.second;
         }
       };
       /// Metadata for a two-dimensional axis definition (coordinates and bins values)

--- a/CepGen/Utils/Graph.cpp
+++ b/CepGen/Utils/Graph.cpp
@@ -28,21 +28,21 @@ namespace cepgen {
     Graph1D::Graph1D(const std::string& name, const std::string& title) : Drawable(name, title) {}
 
     Graph1D& Graph1D::addPoint(double x, double y) {
-      values_[coord_t{x}] = value_t{y};
+      values_[coord_t{x}] = Value{y};
       return *this;
     }
 
     Graph1D& Graph1D::addPoint(double x, double y, double ex, double ey) {
-      values_[coord_t{x, ex}] = value_t{y, ey};
+      values_[coord_t{x, ex}] = Value{y, ey};
       return *this;
     }
 
     double Graph1D::minimum() const {
-      return std::min_element(values_.begin(), values_.end(), CompareAxisByValue())->second.value;
+      return std::min_element(values_.begin(), values_.end(), CompareAxisByValue())->second;
     }
 
     double Graph1D::maximum() const {
-      return std::max_element(values_.begin(), values_.end(), CompareAxisByValue())->second.value;
+      return std::max_element(values_.begin(), values_.end(), CompareAxisByValue())->second;
     }
 
     double Graph1D::chi2(const Graph1D& oth) const {
@@ -55,10 +55,10 @@ namespace cepgen {
                                          << "Please ensure the two graphs have the same values definition.";
         const auto& val1 = kv1.second;
         const auto& val2 = oth.values_.at(kv1.first);
-        double norm = std::pow(val1.value_unc, 2) + std::pow(val2.value_unc, 2);
+        double norm = std::pow(val1.uncertainty(), 2) + std::pow(val2.uncertainty(), 2);
         if (norm == 0.)
           norm = 1.;
-        chi2 += std::pow(val1.value - val2.value, 2) / norm;
+        chi2 += std::pow(val1 - val2, 2) / norm;
       }
       return chi2;
     }
@@ -70,7 +70,7 @@ namespace cepgen {
       return coords;
     }
 
-    const Drawable::value_t Graph1D::valueAt(double val) const {
+    const Value Graph1D::valueAt(double val) const {
       auto it = std::find_if(values_.begin(), values_.end(), [&val](const auto& xv) { return xv.first.value == val; });
       if (it == values_.end())
         throw CG_ERROR("Graph1D:valueAt") << "Failed to retrieve a point a the coordinate x=" << val << ".";
@@ -80,12 +80,12 @@ namespace cepgen {
     Graph2D::Graph2D(const std::string& name, const std::string& title) : Drawable(name, title) {}
 
     Graph2D& Graph2D::addPoint(double x, double y, double z) {
-      values_[coord_t{x}][coord_t{y}] = value_t{z};
+      values_[coord_t{x}][coord_t{y}] = Value{z};
       return *this;
     }
 
     Graph2D& Graph2D::addPoint(double x, double y, double z, double ex, double ey, double ez) {
-      values_[coord_t{x, ex}][coord_t{y, ey}] = value_t{z, ez};
+      values_[coord_t{x, ex}][coord_t{y, ey}] = Value{z, ez};
       return *this;
     }
 
@@ -94,8 +94,7 @@ namespace cepgen {
       size_t np = 0ul;
       for (const auto& xaxis : values_)
         for (const auto& yaxis : xaxis.second)
-          os << utils::format(
-              "\n%6zu: (%5g, %5g) = %5g", np++, xaxis.first.value, yaxis.first.value, yaxis.second.value);
+          os << utils::format("\n%6zu: (%5g, %5g) = %5g", np++, xaxis.first.value, yaxis.first.value, yaxis.second);
     }
 
     std::set<double> Graph2D::xCoords() const {
@@ -113,7 +112,7 @@ namespace cepgen {
       return coords;
     }
 
-    const Drawable::value_t Graph2D::valueAt(double xval, double yval) const {
+    const Value Graph2D::valueAt(double xval, double yval) const {
       for (const auto& xv : values_)
         if (xv.first.value == xval)
           for (const auto& yv : xv.second)

--- a/CepGen/Utils/Graph.h
+++ b/CepGen/Utils/Graph.h
@@ -46,7 +46,7 @@ namespace cepgen {
       /// List of horizontal axis coordinates
       std::set<double> xCoords() const;
       /// Retrieve the value of the graph at a given coordinate
-      const value_t valueAt(double) const;
+      const Value valueAt(double) const;
 
       bool isGraph1D() const override { return true; }
 
@@ -73,7 +73,7 @@ namespace cepgen {
       /// List of vertical axis coordinates
       std::set<double> yCoords() const;
       /// Retrieve the value of the graph at the given coordinates
-      const value_t valueAt(double, double) const;
+      const Value valueAt(double, double) const;
 
       bool isGraph2D() const override { return true; }
 

--- a/CepGen/Utils/Histogram.cpp
+++ b/CepGen/Utils/Histogram.cpp
@@ -113,7 +113,7 @@ namespace cepgen {
         const auto& range_i = binRange(bin);
         axis[coord_t{
             range_i.x(0.5), 0.5 * range_i.range(), utils::format("[%7.2f,%7.2f)", range_i.min(), range_i.max())}] =
-            value_t{value(bin), valueUnc(bin)};
+            value(bin);
       }
       return axis;
     }
@@ -128,8 +128,9 @@ namespace cepgen {
       return range;
     }
 
-    double Hist1D::value(size_t bin) const { return gsl_histogram_get(hist_.get(), bin); }
-    double Hist1D::valueUnc(size_t bin) const { return std::sqrt(gsl_histogram_get(hist_w2_.get(), bin)); }
+    Value Hist1D::value(size_t bin) const {
+      return Value{gsl_histogram_get(hist_.get(), bin), std::sqrt(gsl_histogram_get(hist_w2_.get(), bin))};
+    }
 
     double Hist1D::mean() const { return gsl_histogram_mean(hist_.get()); }
     double Hist1D::rms() const { return gsl_histogram_sigma(hist_.get()); }
@@ -267,9 +268,9 @@ namespace cepgen {
       return range;
     }
 
-    double Hist2D::value(size_t bin_x, size_t bin_y) const { return gsl_histogram2d_get(hist_.get(), bin_x, bin_y); }
-    double Hist2D::valueUnc(size_t bin_x, size_t bin_y) const {
-      return std::sqrt(gsl_histogram2d_get(hist_w2_.get(), bin_x, bin_y));
+    Value Hist2D::value(size_t bin_x, size_t bin_y) const {
+      return Value{gsl_histogram2d_get(hist_.get(), bin_x, bin_y),
+                   std::sqrt(gsl_histogram2d_get(hist_w2_.get(), bin_x, bin_y))};
     }
 
     double Hist2D::meanX() const { return gsl_histogram2d_xmean(hist_.get()); }

--- a/CepGen/Utils/Histogram.h
+++ b/CepGen/Utils/Histogram.h
@@ -70,10 +70,8 @@ namespace cepgen {
       void add(Hist1D, double scaling = 1.);
       void scale(double) override;
 
-      /// Retrieve the value for one bin
-      double value(size_t bin) const;
-      /// Retrieve the absolute uncertainty on one bin value
-      double valueUnc(size_t bin) const;
+      /// Retrieve the value + uncertainty for one bin
+      Value value(size_t bin) const;
 
       /// Axis content
       axis_t axis() const;
@@ -129,10 +127,8 @@ namespace cepgen {
       void add(Hist2D, double scaling = 1.);
       void scale(double) override;
 
-      /// Retrieve the value for one bin
-      double value(size_t bin_x, size_t bin_y) const;
-      /// Retrieve the absolute uncertainty on one bin value
-      double valueUnc(size_t bin_x, size_t bin_y) const;
+      /// Retrieve the value + uncertainty for one bin
+      Value value(size_t bin_x, size_t bin_y) const;
 
       /// Number of x-axis bins
       size_t nbinsX() const;

--- a/CepGen/Utils/Value.cpp
+++ b/CepGen/Utils/Value.cpp
@@ -26,22 +26,14 @@ namespace cepgen {
 
   double Value::relativeUncertainty() const { return val_ == 0. ? 0. : unc_ / val_; }
 
-  Value Value::operator+(double cst) const { return Value{val_ + cst, unc_}; }
-
   Value Value::operator+(const Value& oth) const { return Value{val_ + oth.val_, std::hypot(unc_, oth.unc_)}; }
 
-  Value Value::operator-(double cst) const { return Value{val_ - cst, unc_}; }
-
   Value Value::operator-(const Value& oth) const { return Value{val_ - oth.val_, std::hypot(unc_, oth.unc_)}; }
-
-  Value Value::operator*(double cst) const { return Value{val_ * cst, unc_ * cst}; }
 
   Value Value::operator*(const Value& oth) const {
     const auto prod = val_ * oth.val_;
     return Value{prod, prod * std::hypot(relativeUncertainty(), oth.relativeUncertainty())};
   }
-
-  Value Value::operator/(double cst) const { return Value{val_ / cst, unc_ / cst}; }
 
   Value Value::operator/(const Value& oth) const {
     const auto ratio = val_ / oth.val_;

--- a/CepGen/Utils/Value.cpp
+++ b/CepGen/Utils/Value.cpp
@@ -1,0 +1,52 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <iostream>
+
+#include "CepGen/Utils/Value.h"
+
+namespace cepgen {
+  Value::Value(double val, double unc) : val_(val), unc_(unc) {}
+
+  double Value::relativeUncertainty() const { return val_ == 0. ? 0. : unc_ / val_; }
+
+  Value Value::operator+(double cst) const { return Value{val_ + cst, unc_}; }
+
+  Value Value::operator+(const Value& oth) const { return Value{val_ + oth.val_, std::hypot(unc_, oth.unc_)}; }
+
+  Value Value::operator-(double cst) const { return Value{val_ - cst, unc_}; }
+
+  Value Value::operator-(const Value& oth) const { return Value{val_ - oth.val_, std::hypot(unc_, oth.unc_)}; }
+
+  Value Value::operator*(double cst) const { return Value{val_ * cst, unc_ * cst}; }
+
+  Value Value::operator*(const Value& oth) const {
+    const auto prod = val_ * oth.val_;
+    return Value{prod, prod * std::hypot(relativeUncertainty(), oth.relativeUncertainty())};
+  }
+
+  Value Value::operator/(double cst) const { return Value{val_ / cst, unc_ / cst}; }
+
+  Value Value::operator/(const Value& oth) const {
+    const auto ratio = val_ / oth.val_;
+    return Value{ratio, ratio * std::hypot(relativeUncertainty(), oth.relativeUncertainty())};
+  }
+
+  std::ostream& operator<<(std::ostream& os, const Value& value) { return os << value.val_ << " +/- " << value.unc_; }
+}  // namespace cepgen

--- a/CepGen/Utils/Value.h
+++ b/CepGen/Utils/Value.h
@@ -41,14 +41,26 @@ namespace cepgen {
 
     //--- error propagation operators
 
-    Value operator+(double) const;
     Value operator+(const Value&) const;
-    Value operator-(double) const;
+    template <typename T>
+    inline Value operator+(T cst) const {
+      return Value{val_ + cst, unc_};
+    }
     Value operator-(const Value&) const;
-    Value operator*(double) const;
+    template <typename T>
+    inline Value operator-(T cst) const {
+      return Value{val_ - cst, unc_};
+    }
     Value operator*(const Value&) const;
-    Value operator/(double) const;
+    template <typename T>
+    inline Value operator*(T cst) const {
+      return Value{val_ * cst, unc_ * cst};
+    }
     Value operator/(const Value&) const;
+    template <typename T>
+    inline Value operator/(T cst) const {
+      return Value{val_ / cst, unc_ / cst};
+    }
 
   private:
     double val_;  ///< Central value

--- a/CepGen/Utils/Value.h
+++ b/CepGen/Utils/Value.h
@@ -25,7 +25,7 @@ namespace cepgen {
   /// A scalar value with its uncertainty
   class Value {
   public:
-    explicit Value(double val, double unc = 0.);
+    explicit Value(double val = 0., double unc = 0.);
 
     friend std::ostream& operator<<(std::ostream&, const Value&);
 
@@ -35,6 +35,9 @@ namespace cepgen {
     double uncertainty() const { return unc_; }
     /// Relative uncertainty around the central value
     double relativeUncertainty() const;
+
+    /// Comparison operator
+    bool operator<(const Value& oth) const { return val_ < oth.val_; }
 
     //--- error propagation operators
 

--- a/CepGen/Utils/Value.h
+++ b/CepGen/Utils/Value.h
@@ -1,0 +1,56 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_Utils_Value_h
+#define CepGen_Utils_Value_h
+
+#include <iosfwd>
+
+namespace cepgen {
+  /// A scalar value with its uncertainty
+  class Value {
+  public:
+    explicit Value(double val, double unc = 0.);
+
+    friend std::ostream& operator<<(std::ostream&, const Value&);
+
+    /// Central value extraction
+    operator double() const { return val_; }
+    /// Absolute uncertainty around the central value
+    double uncertainty() const { return unc_; }
+    /// Relative uncertainty around the central value
+    double relativeUncertainty() const;
+
+    //--- error propagation operators
+
+    Value operator+(double) const;
+    Value operator+(const Value&) const;
+    Value operator-(double) const;
+    Value operator-(const Value&) const;
+    Value operator*(double) const;
+    Value operator*(const Value&) const;
+    Value operator/(double) const;
+    Value operator/(const Value&) const;
+
+  private:
+    double val_;  ///< Central value
+    double unc_;  ///< Uncertainty on value
+  };
+}  // namespace cepgen
+
+#endif

--- a/CepGenAddOns/BoostWrapper/IntegratorNaive.cpp
+++ b/CepGenAddOns/BoostWrapper/IntegratorNaive.cpp
@@ -40,15 +40,14 @@ namespace cepgen {
       std::transform(
           limits_.begin(), limits_.end(), std::back_inserter(bounds_), [](const auto& lim) { return lim.raw(); });
     }
-    void integrate(Integrand& integrand, double& result, double& abserr) override {
+    Value integrate(Integrand& integrand) override {
       checkLimits(integrand);
 
       auto funct = [&](const std::vector<double>& coord) -> double { return integrand.eval(coord); };
       boost::math::quadrature::naive_monte_carlo<double, decltype(funct)> mc(funct, bounds_, 1.e-2, true, 1);
       auto task = mc.integrate();
 
-      result_ = result = task.get();
-      err_result_ = abserr = mc.current_error_estimate();
+      return Value{task.get(), mc.current_error_estimate()};
     }
 
   private:

--- a/CepGenAddOns/CubaWrapper/IntegratorCuba.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCuba.cpp
@@ -33,9 +33,9 @@ namespace cepgen {
         maxeval_(steer<int>("maxeval")),
         verbose_(steer<int>("verbose")) {}
 
-  void IntegratorCuba::integrate(Integrand& integr, double& result, double& abserr) {
+  Value IntegratorCuba::integrate(Integrand& integr) {
     gIntegrand = &integr;
-    integrate(result, abserr);
+    return integrate();
   }
 
   ParametersDescription IntegratorCuba::description() {

--- a/CepGenAddOns/CubaWrapper/IntegratorCuba.h
+++ b/CepGenAddOns/CubaWrapper/IntegratorCuba.h
@@ -31,10 +31,10 @@ namespace cepgen {
     static ParametersDescription description();
     static Integrand* gIntegrand;
 
-    void integrate(Integrand& integr, double& result, double& abserr) override;
+    Value integrate(Integrand&) override;
 
   protected:
-    virtual void integrate(double& result, double& abserr) = 0;
+    virtual Value integrate() = 0;
 
     int ncomp_, nvec_;
     double epsrel_, epsabs_;

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaCuhre.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaCuhre.cpp
@@ -27,7 +27,7 @@ namespace cepgen {
   class IntegratorCubaCuhre : public IntegratorCuba {
   public:
     explicit IntegratorCubaCuhre(const ParametersList&);
-    void integrate(double&, double&) override;
+    Value integrate() override;
 
     static ParametersDescription description();
 
@@ -41,7 +41,7 @@ namespace cepgen {
     CG_DEBUG("Integrator:build") << "Cuba-Cuhre integrator built.";
   }
 
-  void IntegratorCubaCuhre::integrate(double& result, double& abserr) {
+  Value IntegratorCubaCuhre::integrate() {
     int nregions, neval, fail;
     double integral, error, prob;
 
@@ -69,8 +69,7 @@ namespace cepgen {
         << "Number of regions needed: " << nregions << ".\nNumber of function evaluations: " << neval
         << "\nError flag: " << fail << ".";
 
-    result_ = result = integral;
-    err_result_ = abserr = error;
+    return Value{integral, error};
   }
 
   ParametersDescription IntegratorCubaCuhre::description() {

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaDivonne.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaDivonne.cpp
@@ -27,7 +27,7 @@ namespace cepgen {
   class IntegratorCubaDivonne : public IntegratorCuba {
   public:
     explicit IntegratorCubaDivonne(const ParametersList&);
-    void integrate(double&, double&) override;
+    Value integrate() override;
 
     static ParametersDescription description();
 
@@ -56,7 +56,7 @@ namespace cepgen {
     CG_DEBUG("Integrator:build") << "Cuba-Divonne integrator built.";
   }
 
-  void IntegratorCubaDivonne::integrate(double& result, double& abserr) {
+  Value IntegratorCubaDivonne::integrate() {
     int nregions, neval, fail;
     double integral, error, prob;
     int ngiven = given_.size();
@@ -96,8 +96,7 @@ namespace cepgen {
             &error,
             &prob);
 
-    result_ = result = integral;
-    err_result_ = abserr = error;
+    return Value{integral, error};
   }
 
   ParametersDescription IntegratorCubaDivonne::description() {

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaSuave.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaSuave.cpp
@@ -27,7 +27,7 @@ namespace cepgen {
   class IntegratorCubaSuave : public IntegratorCuba {
   public:
     explicit IntegratorCubaSuave(const ParametersList&);
-    void integrate(double&, double&) override;
+    Value integrate() override;
 
     static ParametersDescription description();
 
@@ -45,7 +45,7 @@ namespace cepgen {
     CG_DEBUG("Integrator:build") << "Cuba-Suave integrator built.";
   }
 
-  void IntegratorCubaSuave::integrate(double& result, double& abserr) {
+  Value IntegratorCubaSuave::integrate() {
     int neval, fail, nregions;
     double integral, error, prob;
 
@@ -72,8 +72,7 @@ namespace cepgen {
           &error,
           &prob);
 
-    result_ = result = integral;
-    err_result_ = abserr = error;
+    return Value{integral, error};
   }
 
   ParametersDescription IntegratorCubaSuave::description() {

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaVegas.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaVegas.cpp
@@ -27,7 +27,7 @@ namespace cepgen {
   class IntegratorCubaVegas : public IntegratorCuba {
   public:
     explicit IntegratorCubaVegas(const ParametersList&);
-    void integrate(double&, double&) override;
+    Value integrate() override;
 
     static ParametersDescription description();
 
@@ -46,7 +46,7 @@ namespace cepgen {
     CG_DEBUG("Integrator:build") << "Cuba-VEGAS integrator built.";
   }
 
-  void IntegratorCubaVegas::integrate(double& result, double& abserr) {
+  Value IntegratorCubaVegas::integrate() {
     int neval, fail;
     double integral, error, prob;
 
@@ -73,8 +73,7 @@ namespace cepgen {
           &error,
           &prob);
 
-    result_ = result = integral;
-    err_result_ = abserr = error;
+    return Value{integral, error};
   }
 
   ParametersDescription IntegratorCubaVegas::description() {

--- a/CepGenAddOns/DelphesWrapper/DelphesHandler.cpp
+++ b/CepGenAddOns/DelphesWrapper/DelphesHandler.cpp
@@ -29,6 +29,7 @@
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Parameters.h"
 #include "CepGen/Utils/Timer.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   /**
@@ -44,9 +45,7 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override;
-    void setCrossSection(double cross_section, double /*err_cross_section*/) override {
-      cross_section_ = cross_section;
-    }
+    void setCrossSection(const Value& cross_section) override { cross_section_ = cross_section; }
     void operator<<(const Event&) override;
 
   private:
@@ -61,7 +60,7 @@ namespace cepgen {
     DelphesFactory* factory_{nullptr};
     ExRootTreeBranch* evt_branch_{nullptr};
     TObjArray *out_all_parts_{nullptr}, *out_stab_parts_{nullptr}, *out_partons_{nullptr};
-    double cross_section_{-1.};
+    Value cross_section_{0., 1.};
   };
 
   DelphesHandler::DelphesHandler(const ParametersList& params)
@@ -106,7 +105,7 @@ namespace cepgen {
     evt_aux->Number = event_num_++;
     evt_aux->ProcessID = 0;
     evt_aux->Weight = ev.weight;  // events are normally unweighted in CepGen
-    //evt_aux->CrossSection = cross_section_; // not yet fully supported
+    //evt_aux->CrossSection = (double)cross_section_; // not yet fully supported
     evt_aux->ScalePDF = 0.;  // for the time being
     evt_aux->AlphaQED = constants::ALPHA_EM;
     evt_aux->AlphaQCD = constants::ALPHA_QCD;

--- a/CepGenAddOns/GnuplotWrapper/GnuplotDrawer.cpp
+++ b/CepGenAddOns/GnuplotWrapper/GnuplotDrawer.cpp
@@ -146,7 +146,7 @@ namespace cepgen {
         std::ostringstream os;
         os << y;
         for (const auto& x : xvec)
-          os << "\t" << graph.valueAt(x, y).value;
+          os << "\t" << (double)graph.valueAt(x, y);
         cmds += os.str();
       }
       cmds += "EOD";
@@ -194,7 +194,7 @@ namespace cepgen {
         std::ostringstream os;
         os << hist.binRangeY(iy).x(0.5);
         for (size_t ix = 0; ix < hist.nbinsX(); ++ix)
-          os << "\t" << hist.value(ix, iy);
+          os << "\t" << (double)hist.value(ix, iy);
         cmds += os.str();
       }
       cmds += "EOD";
@@ -279,7 +279,7 @@ namespace cepgen {
       cmds += "$DATA_" + rnd + " << EOD";
       for (const auto& pt : graph.points())
         cmds +=
-            merge(std::vector<double>{pt.first.value, pt.first.value_unc, pt.second.value, pt.second.value_unc}, "\t");
+            merge(std::vector<double>{pt.first.value, pt.first.value_unc, pt.second, pt.second.uncertainty()}, "\t");
       cmds += "EOD";
       cmds += "plot '$DATA_" + rnd + "' u 1:3 notitle";
       return cmds;
@@ -295,7 +295,7 @@ namespace cepgen {
 
       cmds += "$DATA_" + rnd + " << EOH";
       for (size_t ibin = 0; ibin < hist.nbins(); ++ibin)
-        cmds += merge(std::vector<double>{hist.binRange(ibin).x(0.5), hist.value(ibin)}, "\t");
+        cmds += merge(std::vector<double>{hist.binRange(ibin).x(0.5), (double)hist.value(ibin)}, "\t");
       cmds += "EOH";
       cmds += "set style data lines";
       cmds += "set yrange [" + std::to_string(hist.minimum()) + ":" + std::to_string(hist.maximum()) + "]";

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2Handler.cpp
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2Handler.cpp
@@ -24,6 +24,7 @@
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Utils/Message.h"
+#include "CepGen/Utils/Value.h"
 #include "CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h"
 
 using namespace HepMC;
@@ -59,8 +60,8 @@ namespace cepgen {
       event.set_event_number(event_num_++);
       output_->write_event(&event);
     }
-    void setCrossSection(double cross_section, double cross_section_err) override {
-      xs_->set_cross_section(cross_section, cross_section_err);
+    void setCrossSection(const Value& cross_section) override {
+      xs_->set_cross_section((double)cross_section, cross_section.uncertainty());
     }
 
   private:

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3Handler.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3Handler.cpp
@@ -69,7 +69,7 @@ namespace cepgen {
       output_->write_event(event);
     }
     void setCrossSection(const Value& cross_section) override {
-      xs_->set_cross_section((double)cross_section, cross_section.uncertainty());
+      xs_->set_cross_section(cross_section, cross_section.uncertainty());
     }
 
   private:

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3Handler.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3Handler.cpp
@@ -25,6 +25,7 @@
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Utils/Message.h"
+#include "CepGen/Utils/Value.h"
 #include "CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h"
 
 using namespace HepMC3;
@@ -67,8 +68,8 @@ namespace cepgen {
       event.set_event_number(event_num_++);
       output_->write_event(event);
     }
-    void setCrossSection(double cross_section, double cross_section_err) override {
-      xs_->set_cross_section(cross_section, cross_section_err);
+    void setCrossSection(const Value& cross_section) override {
+      xs_->set_cross_section((double)cross_section, cross_section.uncertainty());
     }
 
   private:

--- a/CepGenAddOns/HepMC3Wrapper/LHEFHepMCHandler.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/LHEFHepMCHandler.cpp
@@ -22,6 +22,7 @@
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Parameters.h"
+#include "CepGen/Utils/Value.h"
 
 using namespace std;  // account for improper scoping in following includes
 #include <HepMC3/LHEF.h>
@@ -42,7 +43,7 @@ namespace cepgen {
     void initialise() override;
     /// Writer operator
     void operator<<(const Event&) override;
-    void setCrossSection(double, double) override;
+    void setCrossSection(const Value&) override;
 
   private:
     /// Writer object (from HepMC)
@@ -56,13 +57,13 @@ namespace cepgen {
         lhe_output_(new LHEF::Writer(steer<std::string>("filename"))),
         compress_(steer<bool>("compress")) {}
 
-  void LHEFHepMCHandler::setCrossSection(double cross_section, double err) {
+  void LHEFHepMCHandler::setCrossSection(const Value& cross_section) {
     lhe_output_->heprup.NPRUP = 1;
     lhe_output_->heprup.resize();
     lhe_output_->heprup.XMAXUP[0] = 1.;
     lhe_output_->heprup.LPRUP[0] = 1;
-    lhe_output_->heprup.XSECUP[0] = cross_section;
-    lhe_output_->heprup.XERRUP[0] = err;
+    lhe_output_->heprup.XSECUP[0] = (double)cross_section;
+    lhe_output_->heprup.XERRUP[0] = cross_section.uncertainty();
   }
 
   void LHEFHepMCHandler::initialise() {

--- a/CepGenAddOns/MatplotlibWrapper/MatplotlibDrawer.cpp
+++ b/CepGenAddOns/MatplotlibWrapper/MatplotlibDrawer.cpp
@@ -128,9 +128,9 @@ namespace cepgen {
       std::vector<double> x, y, xerr, yerr;
       for (const auto& pt : gr.points()) {
         x.emplace_back(pt.first.value);
-        y.emplace_back(pt.second.value);
+        y.emplace_back(pt.second);
         xerr.emplace_back(pt.first.value_unc);
-        yerr.emplace_back(pt.second.value_unc);
+        yerr.emplace_back(pt.second.uncertainty());
       }
       if ((mode & Mode::logx) && (mode & Mode::logy))
         plt::named_loglog(gr.title(), x, y);
@@ -152,7 +152,7 @@ namespace cepgen {
         for (const auto& yv : xv.second) {
           xrow.emplace_back(xval);
           yrow.emplace_back(yv.first.value);
-          zrow.emplace_back(yv.second.value);
+          zrow.emplace_back(yv.second);
         }
         x.emplace_back(xrow);
         y.emplace_back(yrow);
@@ -166,9 +166,10 @@ namespace cepgen {
     void MatplotlibDrawer::plot(const Hist1D& hist, const Mode& mode) {
       std::vector<double> x, y, yerr;
       for (size_t ibin = 0; ibin < hist.nbins(); ++ibin) {
+        const auto val = hist.value(ibin);
         x.emplace_back(hist.binRange(ibin).x(0.5));
-        y.emplace_back(hist.value(ibin));
-        yerr.emplace_back(hist.valueUnc(ibin));
+        y.emplace_back(val);
+        yerr.emplace_back(val.uncertainty());
       }
       //plt::bar(x, y, "", "", 1., {{"label", hist.title()}});
       //plt::bar(x, y);

--- a/CepGenAddOns/ProMCWrapper/ProMCHandler.cpp
+++ b/CepGenAddOns/ProMCWrapper/ProMCHandler.cpp
@@ -72,7 +72,7 @@ namespace cepgen {
 
   ProMCHandler::~ProMCHandler() {
     ProMCStat stat;
-    stat.set_cross_section_accumulated((double)cross_section_);
+    stat.set_cross_section_accumulated(cross_section_);
     stat.set_cross_section_error_accumulated(cross_section.uncertainty());
     stat.set_luminosity_accumulated(event_num_ / (double)cross_section_);
     stat.set_ntried(event_num_);

--- a/CepGenAddOns/ProMCWrapper/ProMCHandler.cpp
+++ b/CepGenAddOns/ProMCWrapper/ProMCHandler.cpp
@@ -31,6 +31,7 @@
 #include "CepGen/Utils/Filesystem.h"
 #include "CepGen/Utils/Message.h"
 #include "CepGen/Utils/String.h"
+#include "CepGen/Utils/Value.h"
 #include "CepGen/Version.h"
 
 namespace cepgen {
@@ -47,9 +48,7 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override;
-    void setCrossSection(double cross_section, double err) override {
-      cross_section_ = cross_section, cross_section_err_ = err;
-    }
+    void setCrossSection(const Value& cross_section) override { cross_section_ = cross_section; }
     void operator<<(const Event&) override;
 
   private:
@@ -61,7 +60,7 @@ namespace cepgen {
     const bool compress_evt_;
     const std::string log_file_path_;
     std::ofstream log_file_;
-    double cross_section_{-1.}, cross_section_err_{-1.};
+    Value cross_section_{0., 1.};
   };
 
   ProMCHandler::ProMCHandler(const ParametersList& params)
@@ -73,9 +72,9 @@ namespace cepgen {
 
   ProMCHandler::~ProMCHandler() {
     ProMCStat stat;
-    stat.set_cross_section_accumulated(cross_section_);
-    stat.set_cross_section_error_accumulated(cross_section_err_);
-    stat.set_luminosity_accumulated(event_num_ / cross_section_);
+    stat.set_cross_section_accumulated((double)cross_section_);
+    stat.set_cross_section_error_accumulated(cross_section.uncertainty());
+    stat.set_luminosity_accumulated(event_num_ / (double)cross_section_);
     stat.set_ntried(event_num_);
     stat.set_nselected(event_num_);
     stat.set_naccepted(event_num_);

--- a/CepGenAddOns/Pythia6Wrapper/Pythia6Hadroniser.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/Pythia6Hadroniser.cpp
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2021  Laurent Forthomme
+ *  Copyright (C) 2013-2023  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -79,8 +79,6 @@ namespace cepgen {
       inline void readString(const char* param) override { pygive(param); }
       void initialise() override;
       bool run(Event& ev, double& weight, bool full) override;
-
-      void setCrossSection(double, double) override {}
 
     private:
       /// Maximal number of characters to fetch for the particle's name

--- a/CepGenAddOns/Pythia8Wrapper/LHEFPythiaHandler.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/LHEFPythiaHandler.cpp
@@ -117,7 +117,7 @@ namespace cepgen {
   }
 
   void LHEFPythiaHandler::setCrossSection(const Value& cross_section) {
-    lhaevt_->setCrossSection(0, (double)cross_section, cross_section.uncertainty());
+    lhaevt_->setCrossSection(0, cross_section, cross_section.uncertainty());
   }
 
   ParametersDescription LHEFPythiaHandler::description() {

--- a/CepGenAddOns/Pythia8Wrapper/LHEFPythiaHandler.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/LHEFPythiaHandler.cpp
@@ -24,6 +24,7 @@
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Utils/Filesystem.h"
 #include "CepGen/Utils/String.h"
+#include "CepGen/Utils/Value.h"
 #include "CepGenAddOns/Pythia8Wrapper/PythiaEventInterface.h"
 
 namespace cepgen {
@@ -43,7 +44,7 @@ namespace cepgen {
     void initialise() override;
     /// Writer operator
     void operator<<(const Event&) override;
-    void setCrossSection(double, double) override;
+    void setCrossSection(const Value&) override;
 
   private:
     std::unique_ptr<Pythia8::Pythia> pythia_;
@@ -115,8 +116,8 @@ namespace cepgen {
     lhaevt_->eventLHEF();
   }
 
-  void LHEFPythiaHandler::setCrossSection(double cross_section, double cross_section_err) {
-    lhaevt_->setCrossSection(0, cross_section, cross_section_err);
+  void LHEFPythiaHandler::setCrossSection(const Value& cross_section) {
+    lhaevt_->setCrossSection(0, (double)cross_section, cross_section.uncertainty());
   }
 
   ParametersDescription LHEFPythiaHandler::description() {

--- a/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
@@ -29,6 +29,7 @@
 #include "CepGen/Physics/Hadroniser.h"
 #include "CepGen/Physics/Kinematics.h"
 #include "CepGen/Physics/PDG.h"
+#include "CepGen/Utils/Value.h"
 #include "CepGenAddOns/Pythia8Wrapper/PythiaEventInterface.h"
 
 namespace cepgen {
@@ -48,7 +49,7 @@ namespace cepgen {
       void initialise() override;
       bool run(Event& ev, double& weight, bool full) override;
 
-      void setCrossSection(double cross_section, double cross_section_err) override;
+      void setCrossSection(const Value&) override;
 
     private:
       void* enginePtr() override { return (void*)pythia_.get(); }
@@ -158,8 +159,8 @@ namespace cepgen {
         cg_evt_->initLHEF();
     }
 
-    void Pythia8Hadroniser::setCrossSection(double cross_section, double cross_section_err) {
-      cg_evt_->setCrossSection(0, cross_section, cross_section_err);
+    void Pythia8Hadroniser::setCrossSection(const Value& cross_section) {
+      cg_evt_->setCrossSection(0, (double)cross_section, cross_section.uncertainty());
     }
 
     bool Pythia8Hadroniser::run(Event& ev, double& weight, bool full) {

--- a/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
@@ -160,7 +160,7 @@ namespace cepgen {
     }
 
     void Pythia8Hadroniser::setCrossSection(const Value& cross_section) {
-      cg_evt_->setCrossSection(0, (double)cross_section, cross_section.uncertainty());
+      cg_evt_->setCrossSection(0, cross_section, cross_section.uncertainty());
     }
 
     bool Pythia8Hadroniser::run(Event& ev, double& weight, bool full) {

--- a/CepGenAddOns/PythonWrapper/IntegratorVegasPlus.cpp
+++ b/CepGenAddOns/PythonWrapper/IntegratorVegasPlus.cpp
@@ -39,7 +39,7 @@ namespace cepgen {
 
     void setLimits(const std::vector<Limits>& lims) override { lims_ = python::set(lims); }
 
-    void integrate(Integrand& integrand, double& result, double& abs_error) override {
+    Value integrate(Integrand& integrand) override {
       gIntegrand = &integrand;
       const auto iterations = steer<int>("iterations");
       const auto evals = steer<int>("evals");
@@ -54,8 +54,8 @@ namespace cepgen {
       if (vals.size() < 2)
         throw CG_FATAL("IntegratorVegasPlus")
             << "Wrong multiplicity of result returned from Python's Vegas: " << vals << ".";
-      result_ = result = vals[0];
-      err_result_ = abs_error = vals[1];
+
+      return Value{vals[0], vals[1]};
     }
 
     static ParametersDescription description() {

--- a/CepGenAddOns/ROOTWrapper/ROOTDrawer.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTDrawer.cpp
@@ -207,8 +207,9 @@ namespace cepgen {
       gr.SetTitle(delatexify(graph.title()));
       int i = 0;
       for (const auto& it : graph.points()) {
-        gr.SetPoint(i, it.first.value, it.second.value);
-        gr.SetPointError(i, it.first.value_unc, it.second.value_unc);
+        const auto& val = it.second;
+        gr.SetPoint(i, it.first.value, val);
+        gr.SetPointError(i, it.first.value_unc, val.uncertainty());
         ++i;
       }
       gr.SetLineWidth(3);
@@ -223,8 +224,9 @@ namespace cepgen {
         const auto& ax_x = it_x.first.value;
         for (const auto& it_y : it_x.second) {
           const auto& ax_y = it_y.first.value;
-          gr.SetPoint(i, ax_x, ax_y, it_y.second.value);
-          gr.SetPointError(i, 0., 0., it_y.second.value_unc);
+          const auto& val = it_y.second;
+          gr.SetPoint(i, ax_x, ax_y, val);
+          gr.SetPointError(i, 0., 0., val.uncertainty());
           ++i;
         }
       }
@@ -236,8 +238,9 @@ namespace cepgen {
       TH1D h(hist.name().c_str(), delatexify(hist.title()), hist.nbins(), rng.min(), rng.max());
       h.SetBinContent(0, hist.underflow());
       for (size_t i = 0; i < hist.nbins(); ++i) {
-        h.SetBinContent(i + 1, hist.value(i));
-        h.SetBinError(i + 1, hist.valueUnc(i));
+        const auto val = hist.value(i);
+        h.SetBinContent(i + 1, val);
+        h.SetBinError(i + 1, val.uncertainty());
       }
       h.SetBinContent(hist.nbins() + 1, hist.overflow());
       h.GetXaxis()->SetTitle(delatexify(hist.xAxis().label()));
@@ -257,8 +260,9 @@ namespace cepgen {
              rng_y.max());
       for (size_t ix = 0; ix < hist.nbinsX(); ++ix)
         for (size_t iy = 0; iy < hist.nbinsY(); ++iy) {
-          h.SetBinContent(ix + 1, iy + 1, hist.value(ix, iy));
-          h.SetBinError(ix + 1, iy + 1, hist.valueUnc(ix, iy));
+          const auto val = hist.value(ix, iy);
+          h.SetBinContent(ix + 1, iy + 1, val);
+          h.SetBinError(ix + 1, iy + 1, val.uncertainty());
         }
       h.SetBinContent(0, 0, hist.outOfRange().at(Hist2D::contents_t::LT_LT));
       h.SetBinContent(0, 1, hist.outOfRange().at(Hist2D::contents_t::LT_IN));

--- a/CepGenAddOns/ROOTWrapper/ROOTHistsHandler.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTHistsHandler.cpp
@@ -182,21 +182,21 @@ namespace cepgen {
   void ROOTHistsHandler::operator<<(const Event& ev) {
     //--- increment the corresponding histograms
     for (const auto& h_var : hists1d_)
-      h_var.second->Fill(browser_.get(ev, h_var.first), (double)cross_section_);
+      h_var.second->Fill(browser_.get(ev, h_var.first), cross_section_);
     for (const auto& h_var : hists2d_)
-      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
+      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
     for (const auto& h_var : hists3d_)
       h_var.second->Fill(browser_.get(ev, h_var.first[0]),
                          browser_.get(ev, h_var.first[1]),
                          browser_.get(ev, h_var.first[2]),
-                         (double)cross_section_);
+                         cross_section_);
     for (const auto& h_var : profiles1d_)
-      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
+      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
     for (const auto& h_var : profiles2d_)
       h_var.second->Fill(browser_.get(ev, h_var.first[0]),
                          browser_.get(ev, h_var.first[1]),
                          browser_.get(ev, h_var.first[2]),
-                         (double)cross_section_);
+                         cross_section_);
   }
 
   ParametersDescription ROOTHistsHandler::description() {

--- a/CepGenAddOns/ROOTWrapper/ROOTHistsHandler.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTHistsHandler.cpp
@@ -30,6 +30,7 @@
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Utils/Limits.h"
 #include "CepGen/Utils/String.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   /**
@@ -45,7 +46,7 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override {}
-    void setCrossSection(double cross_section, double) override { cross_section_ = cross_section; }
+    void setCrossSection(const Value& cross_section) override { cross_section_ = cross_section; }
     void operator<<(const Event&) override;
 
   private:
@@ -58,7 +59,7 @@ namespace cepgen {
 
     const ParametersList variables_;
 
-    double cross_section_{1.};
+    Value cross_section_{1., 0.};
     const utils::EventBrowser browser_;
   };
 
@@ -181,21 +182,21 @@ namespace cepgen {
   void ROOTHistsHandler::operator<<(const Event& ev) {
     //--- increment the corresponding histograms
     for (const auto& h_var : hists1d_)
-      h_var.second->Fill(browser_.get(ev, h_var.first), cross_section_);
+      h_var.second->Fill(browser_.get(ev, h_var.first), (double)cross_section_);
     for (const auto& h_var : hists2d_)
-      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
+      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
     for (const auto& h_var : hists3d_)
       h_var.second->Fill(browser_.get(ev, h_var.first[0]),
                          browser_.get(ev, h_var.first[1]),
                          browser_.get(ev, h_var.first[2]),
-                         cross_section_);
+                         (double)cross_section_);
     for (const auto& h_var : profiles1d_)
-      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
+      h_var.second->Fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
     for (const auto& h_var : profiles2d_)
       h_var.second->Fill(browser_.get(ev, h_var.first[0]),
                          browser_.get(ev, h_var.first[1]),
                          browser_.get(ev, h_var.first[2]),
-                         cross_section_);
+                         (double)cross_section_);
   }
 
   ParametersDescription ROOTHistsHandler::description() {

--- a/CepGenAddOns/ROOTWrapper/ROOTTreeHandler.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTTreeHandler.cpp
@@ -28,6 +28,7 @@
 #include "CepGen/Parameters.h"
 #include "CepGen/Process/Process.h"
 #include "CepGen/Utils/String.h"
+#include "CepGen/Utils/Value.h"
 #include "CepGen/Version.h"
 #include "CepGenAddOns/ROOTWrapper/ROOTTreeInfo.h"
 
@@ -48,7 +49,7 @@ namespace cepgen {
     void initialise() override;
     /// Writer operator
     void operator<<(const Event&) override;
-    void setCrossSection(double, double) override;
+    void setCrossSection(const Value&) override;
 
   private:
     std::string generateFilename() const;
@@ -94,9 +95,9 @@ namespace cepgen {
     run_tree_.num_events += 1;
   }
 
-  void ROOTTreeHandler::setCrossSection(double cross_section, double cross_section_err) {
-    run_tree_.xsect = cross_section;
-    run_tree_.errxsect = cross_section_err;
+  void ROOTTreeHandler::setCrossSection(const Value& cross_section) {
+    run_tree_.xsect = (double)cross_section;
+    run_tree_.errxsect = cross_section.uncertainty();
   }
 
   std::string ROOTTreeHandler::generateFilename() const {

--- a/CepGenAddOns/ROOTWrapper/ROOTTreeHandler.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTTreeHandler.cpp
@@ -96,7 +96,7 @@ namespace cepgen {
   }
 
   void ROOTTreeHandler::setCrossSection(const Value& cross_section) {
-    run_tree_.xsect = (double)cross_section;
+    run_tree_.xsect = cross_section;
     run_tree_.errxsect = cross_section.uncertainty();
   }
 

--- a/CepGenAddOns/RivetWrapper/YODADrawer.cpp
+++ b/CepGenAddOns/RivetWrapper/YODADrawer.cpp
@@ -108,7 +108,7 @@ namespace cepgen {
     YODA::Scatter2D YODADrawer<T>::convert(const Graph1D& graph) {
       YODA::Scatter2D gr(path(graph.name()), graph.title());
       for (const auto& it : graph.points())
-        gr.addPoint(it.first.value, it.second.value, 0. /* FIXME not yet supported */, it.second.value_unc);
+        gr.addPoint(it.first.value, it.second, 0. /* FIXME not yet supported */, it.second.uncertainty());
       //gr.setAnnotation("xlabel", graph.xAxis().label());
       //gr.setAnnotation("ylabel", graph.yAxis().label());
       return gr;
@@ -121,7 +121,7 @@ namespace cepgen {
         const auto& ax_x = it_x.first.value;
         for (const auto& it_y : it_x.second) {
           const auto& ax_y = it_y.first.value;
-          gr.addPoint(ax_x, ax_y, it_y.second.value, 0., 0., it_y.second.value_unc);
+          gr.addPoint(ax_x, ax_y, it_y.second, 0., 0., it_y.second.uncertainty());
         }
       }
       //gr.setAnnotation("xlabel", graph.xAxis().label());
@@ -133,8 +133,10 @@ namespace cepgen {
     YODA::Histo1D YODADrawer<T>::convert(const Hist1D& hist) {
       const auto& rng = hist.range();
       YODA::Histo1D h(hist.nbins(), rng.min(), rng.max(), path(hist.name()), hist.title());
-      for (size_t i = 0; i < hist.nbins(); ++i)
-        h.fillBin(i, hist.value(i), std::pow(hist.valueUnc(i), 2));
+      for (size_t i = 0; i < hist.nbins(); ++i) {
+        const auto val = hist.value(i);
+        h.fillBin(i, val, std::pow(val.uncertainty(), 2));
+      }
       //h.setAnnotation("xlabel", hist.xAxis().label());
       //h.setAnnotation("ylabel", hist.yAxis().label());
       return h;
@@ -152,8 +154,10 @@ namespace cepgen {
                       path(hist.name()),
                       hist.title());
       for (size_t ix = 0; ix < hist.nbinsX(); ++ix)
-        for (size_t iy = 0; iy < hist.nbinsY(); ++iy)
-          h.fillBin((ix + 1) * (iy + 1), hist.value(ix, iy), std::pow(hist.valueUnc(ix, iy), 2));
+        for (size_t iy = 0; iy < hist.nbinsY(); ++iy) {
+          const auto val = hist.value(ix, iy);
+          h.fillBin((ix + 1) * (iy + 1), val, std::pow(val.uncertainty(), 2));
+        }
       //h.setAnnotation("xlabel", hist.xAxis().label());
       //h.setAnnotation("ylabel", hist.yAxis().label());
       return h;

--- a/CepGenAddOns/RivetWrapper/YODAHistsHandler.cpp
+++ b/CepGenAddOns/RivetWrapper/YODAHistsHandler.cpp
@@ -34,6 +34,7 @@
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Utils/Limits.h"
 #include "CepGen/Utils/String.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
   /**
@@ -51,7 +52,7 @@ namespace cepgen {
     static ParametersDescription description();
 
     void initialise() override {}
-    void setCrossSection(double cross_section, double) override { cross_section_ = cross_section; }
+    void setCrossSection(const Value& cross_section) override { cross_section_ = cross_section; }
     void operator<<(const Event&) override;
 
   private:
@@ -63,7 +64,7 @@ namespace cepgen {
     YODA::Counter weight_cnt_;
     const ParametersList variables_;
 
-    double cross_section_{1.};
+    Value cross_section_{1., 0.};
     const utils::EventBrowser browser_;
   };
 
@@ -147,16 +148,16 @@ namespace cepgen {
   void YODAHistsHandler<T>::operator<<(const Event& ev) {
     //--- increment the corresponding histograms
     for (auto& h_var : hists1d_)
-      h_var.second.fillBin(browser_.get(ev, h_var.first), cross_section_);
+      h_var.second.fillBin(browser_.get(ev, h_var.first), (double)cross_section_);
     for (auto& h_var : hists2d_)
-      h_var.second.fillBin(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
+      h_var.second.fillBin(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
     for (auto& h_var : profiles1d_)
-      h_var.second.fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
+      h_var.second.fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
     for (auto& h_var : profiles2d_)
       h_var.second.fill(browser_.get(ev, h_var.first[0]),
                         browser_.get(ev, h_var.first[1]),
                         browser_.get(ev, h_var.first[2]),
-                        cross_section_);
+                        (double)cross_section_);
     weight_cnt_.fill(ev.weight);
   }
 

--- a/CepGenAddOns/RivetWrapper/YODAHistsHandler.cpp
+++ b/CepGenAddOns/RivetWrapper/YODAHistsHandler.cpp
@@ -148,16 +148,16 @@ namespace cepgen {
   void YODAHistsHandler<T>::operator<<(const Event& ev) {
     //--- increment the corresponding histograms
     for (auto& h_var : hists1d_)
-      h_var.second.fillBin(browser_.get(ev, h_var.first), (double)cross_section_);
+      h_var.second.fillBin(browser_.get(ev, h_var.first), cross_section_);
     for (auto& h_var : hists2d_)
-      h_var.second.fillBin(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
+      h_var.second.fillBin(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
     for (auto& h_var : profiles1d_)
-      h_var.second.fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), (double)cross_section_);
+      h_var.second.fill(browser_.get(ev, h_var.first[0]), browser_.get(ev, h_var.first[1]), cross_section_);
     for (auto& h_var : profiles2d_)
       h_var.second.fill(browser_.get(ev, h_var.first[0]),
                         browser_.get(ev, h_var.first[1]),
                         browser_.get(ev, h_var.first[2]),
-                        (double)cross_section_);
+                        cross_section_);
     weight_cnt_.fill(ev.weight);
   }
 

--- a/CepGenAddOns/TopdrawerWrapper/TopdrawerDrawer.cpp
+++ b/CepGenAddOns/TopdrawerWrapper/TopdrawerDrawer.cpp
@@ -228,7 +228,8 @@ namespace cepgen {
       Piper::Commands cmds;
       for (size_t i = 0; i < hist.nbins(); ++i) {
         const auto& bin = hist.binRange(i);
-        cmds += format("%g,%g,%g,%g", bin.x(0.5), hist.value(i), 0.5 * bin.range(), hist.valueUnc(i));
+        const auto& val = hist.value(i);
+        cmds += format("%g,%g,%g,%g", bin.x(0.5), val, 0.5 * bin.range(), val.uncertainty());
       }
       cmds += "HIST";
       return cmds;

--- a/src/cepgen.cc
+++ b/src/cepgen.cc
@@ -93,8 +93,7 @@ int main(int argc, char* argv[]) {
     CG_LOG << gen.parameters();
 
     //--- let there be a cross-section...
-    double xsec = 0., err = 0.;
-    gen.computeXsection(xsec, err);
+    gen.computeXsection();
 
     if (params.generation().enabled())
       //--- events generation starts here

--- a/src/utils/cepgenPlotNachtmannAmplitudes.cc
+++ b/src/utils/cepgenPlotNachtmannAmplitudes.cc
@@ -100,8 +100,7 @@ int main(int argc, char* argv[]) {
       double phi1 = params[1] * 2. * M_PI, phi2 = params[3] * 2. * M_PI;
       return dsig(theta1, phi1, theta2, phi2);
     });
-    double val, unc;
-    integrator->integrate(integr, val, unc);
+    auto val = integrator->integrate(integr);
     return 3. * kin.beta * std::pow(2., -13) * std::pow(M_1_PI, -3) / shat * val;
   };
 

--- a/test/benchmarks/generator.cc
+++ b/test/benchmarks/generator.cc
@@ -57,8 +57,7 @@ int main(int argc, char* argv[]) {
   for (const auto& integrator_name : integrators)
     bench.context("integrator", integrator_name).run(process + "+" + integrator_name, [&] {
       gen.setIntegrator(cepgen::IntegratorFactory::get().build(integrator_name));
-      double xsec, xsec_unc;
-      gen.computeXsection(xsec, xsec_unc);
+      gen.computeXsection();
     });
   render_benchmark(bench, outputs);
 

--- a/test/benchmarks/integrator.cc
+++ b/test/benchmarks/integrator.cc
@@ -56,8 +56,7 @@ int main(int argc, char* argv[]) {
     for (const auto& integrator_name : integrators)
       bench.context("integrator", integrator_name).run(functional_parser + "+" + integrator_name, [&] {
         auto integr = cepgen::IntegratorFactory::get().build(integrator_name);
-        double result, unc;
-        integr->integrate(integrand, result, unc);
+        integr->integrate(integrand);
       });
   }
   render_benchmark(bench, outputs);

--- a/test/physics/event_writer.cc
+++ b/test/physics/event_writer.cc
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
   }
 
   auto writer = EventExporterFactory::get().build(type);
-  writer->setCrossSection(1., 2.);
+  writer->setCrossSection(Value{1., 2.});
 
   Event ev;
 

--- a/test/physics/processes_cross_sections.cc
+++ b/test/physics/processes_cross_sections.cc
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2022  Laurent Forthomme
+ *  Copyright (C) 2013-2023  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -93,16 +93,15 @@ int main(int argc, char* argv[]) {
 
       tmr.reset();
 
-      double new_cs, err_new_cs;
-      gen.computeXsection(new_cs, err_new_cs);
+      const auto new_cs = gen.computeXsection();
 
       const double ratio = new_cs / test.ref_cs;
-      const double err_ratio = ratio * hypot(err_new_cs / new_cs, test.err_ref_cs / test.ref_cs);
-      const double pull = (new_cs - test.ref_cs) / hypot(err_new_cs, test.err_ref_cs);
+      const double err_ratio = ratio * hypot(new_cs.uncertainty() / new_cs, test.err_ref_cs / test.ref_cs);
+      const double pull = (new_cs - test.ref_cs) / hypot(new_cs.uncertainty(), test.err_ref_cs);
 
       CG_DEBUG("main") << "Computed cross section:\n\t"
                        << "Ref.   = " << test.ref_cs << " +/- " << test.err_ref_cs << "\n\t"
-                       << "CepGen = " << new_cs << " +/- " << err_new_cs << "\n\t"
+                       << "CepGen = " << new_cs << "\n\t"
                        << "Ratio: " << ratio << " +/- " << err_ratio << "\n\t"
                        << "Pull: " << pull << ".\n\t"
                        << "Computation time: " << tmr.elapsed() * 1.e3 << " ms.";

--- a/test/utils/integrator.cc
+++ b/test/utils/integrator.cc
@@ -71,15 +71,13 @@ int main(int argc, char* argv[]) {
 
     //--- integration part
     size_t i = 0;
-    double result, error;
     for (auto& test : tests) {
       if (!test.lims.empty())
         integr->setLimits(test.lims);
-      integr->integrate(test.integrand, result, error);
+      auto res = integr->integrate(test.integrand);
       const auto test_name = integrator + " test " + to_string(i);
-      CG_DEBUG("main") << "Test " << i << ": ref.: " << test.result << ", result: " << result << " +/- " << error
-                       << ".";
-      CG_TEST_UNCERT(fabs(test.result - result), error, num_sigma, test_name + " rel. unc. control");
+      CG_DEBUG("main") << "Test " << i << ": ref.: " << test.result << ", result: " << res << ".";
+      CG_TEST_UNCERT(fabs(test.result - res), res.uncertainty(), num_sigma, test_name + " rel. unc. control");
       ++i;
     }
   }


### PR DESCRIPTION
This PR introduces the `cepgen::Value` object to handle both a quantile and its total uncertainty. This baseline implementation unlocks the concept of error propagation for future development on theoretical uncertainties.