### PR TITLE
LPAIR: support for all fermion types

### DIFF
--- a/Cards/lpair_ttbar_cfg.py
+++ b/Cards/lpair_ttbar_cfg.py
@@ -1,0 +1,35 @@
+import Config.Core as cepgen
+from Config.PDG_cfi import PDG
+from Config.generator_cff import generator as _gen
+#from Config.Timer_cfi import timer  # enable timing framework
+
+process = cepgen.Module('lpair',
+    processParameters = cepgen.Parameters(
+        mode = cepgen.ProcessMode.InelasticInelastic,
+        pair = PDG.top,
+    ),
+    inKinematics = cepgen.Parameters(
+        pz = (6500., 6500.),
+        structureFunctions = cepgen.StructureFunctions.LUXlike,
+    ),
+    outKinematics = cepgen.Parameters(
+        pt = (0.,),
+        energy = (0.,),
+        eta = (-2.5, 2.5),
+        mx = (1.07, 1000.),
+    ),
+)
+
+generator = _gen.clone(
+    numEvents = 100000,
+    printEvery = 10000,
+)
+
+text = cepgen.Module('text',
+    histVariables={
+        'm(4)': cepgen.Parameters(xbins=[float(bin) for bin in range(200, 1500, 50)]),
+        'pt(7):pt(8)': cepgen.Parameters(xrange=(0., 750.), yrange=(0., 750.), log=True)
+    }
+)
+dump = cepgen.Module('dump', printEvery = generator.printEvery)
+output = cepgen.Sequence(text, dump)

--- a/CepGen/CollinearFluxes/KTIntegratedFlux.cpp
+++ b/CepGen/CollinearFluxes/KTIntegratedFlux.cpp
@@ -33,7 +33,7 @@ namespace cepgen {
   public:
     explicit KTIntegratedFlux(const ParametersList& params)
         : CollinearFlux(params),
-          integr_(AnalyticIntegratorFactory::get().build(params.get<ParametersList>("integrator"))),
+          integr_(AnalyticIntegratorFactory::get().build(steer<ParametersList>("integrator"))),
           flux_(KTFluxFactory::get().build(steer<ParametersList>("ktFlux"))),
           kt2_range_(steer<Limits>("kt2range")),
           func_q2_([&](double kt2, void* params) {

--- a/CepGen/Integration/Integrator.cpp
+++ b/CepGen/Integration/Integrator.cpp
@@ -24,10 +24,7 @@
 
 namespace cepgen {
   Integrator::Integrator(const ParametersList& params)
-      : NamedModule(params),
-        seed_(params_.get<int>("seed", time(nullptr))),
-        verbosity_(steer<int>("verbose")),
-        rnd_(0., 1.) {}
+      : NamedModule(params), seed_(steer<int>("seed")), verbosity_(steer<int>("verbose")), rnd_(0., 1.) {}
 
   void Integrator::checkLimits(const Integrand& integrand) {
     const auto ps_size = integrand.size();

--- a/CepGen/KTFluxes/InelasticKTFluxes.cpp
+++ b/CepGen/KTFluxes/InelasticKTFluxes.cpp
@@ -28,8 +28,7 @@ namespace cepgen {
   class InelasticNucleonKTFlux : public KTFlux {
   public:
     explicit InelasticNucleonKTFlux(const ParametersList& params)
-        : KTFlux(params),
-          sf_(StructureFunctionsFactory::get().build(params.get<ParametersList>("structureFunctions"))) {
+        : KTFlux(params), sf_(StructureFunctionsFactory::get().build(steer<ParametersList>("structureFunctions"))) {
       if (!sf_)
         throw CG_FATAL("InelasticNucleonKTFlux") << "Inelastic kT flux requires a modelling of structure functions!";
     }

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -149,6 +149,7 @@ private:
     double w31 = 0.;  ///< \f$\delta_1=m_3^2-m_1^2\f$ as defined in \cite Vermaseren:1982cz
     double w52 = 0.;  ///< \f$\delta_4=m_5^2-m_2^2\f$ as defined in \cite Vermaseren:1982cz
   } masses_;
+  double charge_factor_{0.};
 
   //-- incoming beam particles
   double ep1_{0.};  ///< energy of the first proton-like incoming particle
@@ -241,7 +242,8 @@ private:
 //---------------------------------------------------------------------------------------------
 
 void LPAIR::prepareKinematics() {
-  masses_.Ml2 = event()(Particle::CentralSystem)[0].momentum().mass2();
+  masses_.Ml2 = pair_.mass * pair_.mass;
+  charge_factor_ = std::pow(pair_.charge / 3., 4);
 
   formfac_ = FormFactorsFactory::get().build(kinematics().incomingBeams().formFactors());
   strfun_ = StructureFunctionsFactory::get().build(kinematics().incomingBeams().structureFunctions());
@@ -743,7 +745,7 @@ double LPAIR::computeWeight() {
   const double ecm6 = m_w4_ / (2. * mc4_), pp6cm = std::sqrt(ecm6 * ecm6 - masses_.Ml2);
   const double alpha1 = alphaEM(std::sqrt(-t1())), alpha2 = alphaEM(std::sqrt(-t2()));
 
-  jacobian_ *= pp6cm * constb_ * alpha1 * alpha1 * alpha2 * alpha2 / mc4_ / s();
+  jacobian_ *= pp6cm * constb_ * charge_factor_ * alpha1 * alpha1 * alpha2 * alpha2 / mc4_ / s();
 
   // Let the most obscure part of this code begin...
 


### PR DESCRIPTION
This PR introduces the possibility to generate two-photon production of fermion pairs (in general) with the LPAIR process. I.e. it now accounts for fermion charge when computing the cross section.

For instance, for a 13 TeV p-p collision with standard dipole elastic/LUXlike inelastic structure functions set of conditions (with standard rapidity cuts < 2.5, and no transverse momentum selection):

| Process mode | Cross section (fb) |
|----------------------|---------------------------|
| Elastic               | 0.1506(10)              |
| Single-diss.      | 2*0.1029(4)            |
| Double-diss.    | 2.853(36)                |