### PR TITLE
Random number generator engines

### DIFF
--- a/CepGen/Integration/Integrator.cpp
+++ b/CepGen/Integration/Integrator.cpp
@@ -26,8 +26,7 @@
 namespace cepgen {
   Integrator::Integrator(const ParametersList& params)
       : NamedModule(params),
-        rnd_gen_(RandomGeneratorFactory::get().build(
-            steer<ParametersList>("randomGenerator").set<unsigned long long>("seed", steer<int>("seed")))),
+        rnd_gen_(RandomGeneratorFactory::get().build(steer<ParametersList>("randomGenerator"))),
         verbosity_(steer<int>("verbose")) {}
 
   void Integrator::checkLimits(const Integrand& integrand) {
@@ -78,7 +77,6 @@ namespace cepgen {
   ParametersDescription Integrator::description() {
     auto desc = ParametersDescription();
     desc.setDescription("Unnamed integrator");
-    desc.add<int>("seed", time(nullptr)).setDescription("Random number generator seed");
     desc.add<int>("verbose", 1).setDescription("Verbosity level");
     desc.add<ParametersDescription>("randomGenerator", ParametersDescription().setName<std::string>("stl"))
         .setDescription("random number generator engine");

--- a/CepGen/Integration/Integrator.h
+++ b/CepGen/Integration/Integrator.h
@@ -19,10 +19,10 @@
 #ifndef CepGen_Integration_Integrator_h
 #define CepGen_Integration_Integrator_h
 
-#include <random>
 #include <vector>
 
 #include "CepGen/Modules/NamedModule.h"
+#include "CepGen/Utils/RandomGenerator.h"
 #include "CepGen/Utils/Value.h"
 
 namespace cepgen {
@@ -56,11 +56,9 @@ namespace cepgen {
                            const std::vector<Limits>&);
 
   protected:
-    const unsigned long seed_;    ///< Random number generator seed
+    const std::unique_ptr<utils::RandomGenerator> rnd_gen_;
     int verbosity_;               ///< Integrator verbosity
     std::vector<Limits> limits_;  ///< List of per-variable integration limits
-    mutable std::default_random_engine rnd_gen_;
-    mutable std::uniform_real_distribution<double> rnd_;
   };
 }  // namespace cepgen
 

--- a/CepGen/Integration/IntegratorGSL.cpp
+++ b/CepGen/Integration/IntegratorGSL.cpp
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2022  Laurent Forthomme
+ *  Copyright (C) 2013-2023  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,33 +23,7 @@
 
 namespace cepgen {
   IntegratorGSL::IntegratorGSL(const ParametersList& params) : Integrator(params) {
-    //--- initialise the random number generator
-    gsl_rng_type* rng_engine = nullptr;
-    switch (steer<int>("rngEngine")) {
-      case 0:
-      default:
-        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_mt19937);
-        break;
-      case 1:
-        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_taus2);
-        break;
-      case 2:
-        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_gfsr4);
-        break;
-      case 3:
-        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_ranlxs0);
-        break;
-    }
-    if (!rng_engine)
-      throw CG_FATAL("Integrator:build") << "Random number generator engine not set!";
-
-    gsl_rng_.reset(gsl_rng_alloc(rng_engine));
-    gsl_rng_set(gsl_rng_.get(), seed_);
-
-    //--- a bit of printout for debugging
-
-    CG_DEBUG("Integrator:build") << "Random numbers generator: " << gsl_rng_name(gsl_rng_.get()) << ".\n\t"
-                                 << "Seed: " << seed_ << ".";
+    CG_DEBUG("Integrator:build") << "Random numbers generator: " << gsl_rng_name(rnd_gen_->engine<gsl_rng>()) << ".";
   }
 
   void IntegratorGSL::setIntegrand(Integrand& integrand) {
@@ -76,16 +50,9 @@ namespace cepgen {
     }
   }
 
-  double IntegratorGSL::uniform(const Limits& limits) const {
-    if (!gsl_rng_)
-      throw CG_FATAL("Integrator:uniform") << "Random number generator has not been initialised!";
-    return limits.x(gsl_rng_uniform(gsl_rng_.get()));
-  }
-
   ParametersDescription IntegratorGSL::description() {
     auto desc = Integrator::description();
-    desc.add<int>("rngEngine", 0)
-        .setDescription("Random number generator engine (0 = MT19937, 1 = Taus2, 2 = Gfsr4, 3 = RanLXS0)");
+    desc.add<ParametersDescription>("randomGenerator", ParametersDescription().setName<std::string>("gsl"));
     return desc;
   }
 }  // namespace cepgen

--- a/CepGen/Integration/IntegratorGSL.h
+++ b/CepGen/Integration/IntegratorGSL.h
@@ -34,7 +34,6 @@ namespace cepgen {
 
     static ParametersDescription description();
 
-    double uniform(const Limits&) const override;
     void setLimits(const std::vector<Limits>&) override;
 
   protected:
@@ -44,13 +43,6 @@ namespace cepgen {
     /// GSL structure storing the function to be integrated by this
     /// integrator instance (along with its parameters)
     std::unique_ptr<gsl_monte_function> function_;
-    /// A deleter object for GSL's random number generator
-    struct gsl_rng_deleter {
-      /// Destructor method for the random number generator service
-      inline void operator()(gsl_rng* rng) { gsl_rng_free(rng); }
-    };
-    /// Instance of random number generator service
-    std::unique_ptr<gsl_rng, gsl_rng_deleter> gsl_rng_;
     std::vector<double> xlow_, xhigh_;
   };
 }  // namespace cepgen

--- a/CepGen/Integration/IntegratorMISER.cpp
+++ b/CepGen/Integration/IntegratorMISER.cpp
@@ -71,7 +71,7 @@ namespace cepgen {
                                         &xhigh_[0],
                                         function_->dim,
                                         ncvg_,
-                                        gsl_rng_.get(),
+                                        rnd_gen_->engine<gsl_rng>(),
                                         miser_state_.get(),
                                         &result,
                                         &abserr);

--- a/CepGen/Integration/IntegratorPlain.cpp
+++ b/CepGen/Integration/IntegratorPlain.cpp
@@ -51,7 +51,7 @@ namespace cepgen {
                                         &xhigh_[0],
                                         function_->dim,
                                         ncvg_,
-                                        gsl_rng_.get(),
+                                        rnd_gen_->engine<gsl_rng>(),
                                         pln_state.get(),
                                         &result,
                                         &abserr);

--- a/CepGen/Integration/IntegratorVegas.cpp
+++ b/CepGen/Integration/IntegratorVegas.cpp
@@ -113,7 +113,7 @@ namespace cepgen {
                                           &xhigh_[0],
                                           function_->dim,
                                           0.2 * ncvg_,
-                                          gsl_rng_.get(),
+                                          rnd_gen_->engine<gsl_rng>(),
                                           vegas_state_.get(),
                                           &result,
                                           &abserr);
@@ -148,7 +148,7 @@ namespace cepgen {
                                         &xhigh_[0],
                                         function_->dim,
                                         ncall,
-                                        gsl_rng_.get(),
+                                        rnd_gen_->engine<gsl_rng>(),
                                         vegas_state_.get(),
                                         &result,
                                         &abserr);

--- a/CepGen/Modules/FunctionalFactory.h
+++ b/CepGen/Modules/FunctionalFactory.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2021  Laurent Forthomme
+ *  Copyright (C) 2013-2023  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,15 +24,13 @@
 /** \file */
 
 /// Add a generic functional object builder definition
-#define REGISTER_FUNCTIONAL(name, obj)                                           \
-  namespace cepgen {                                                             \
-    namespace utils {                                                            \
-      struct BUILDERNM(obj) {                                                    \
-        BUILDERNM(obj)() { FunctionalFactory::get().registerModule<obj>(name); } \
-      };                                                                         \
-      static const BUILDERNM(obj) gFunct##obj;                                   \
-    }                                                                            \
-  }                                                                              \
+#define REGISTER_FUNCTIONAL(name, obj)                                         \
+  namespace cepgen {                                                           \
+    struct BUILDERNM(obj) {                                                    \
+      BUILDERNM(obj)() { FunctionalFactory::get().registerModule<obj>(name); } \
+    };                                                                         \
+    static const BUILDERNM(obj) gFunct##obj;                                   \
+  }                                                                            \
   static_assert(true, "")
 
 namespace cepgen {

--- a/CepGen/Modules/ListModules.cpp
+++ b/CepGen/Modules/ListModules.cpp
@@ -36,6 +36,7 @@
 #include "CepGen/Modules/IntegratorFactory.h"
 #include "CepGen/Modules/PartonFluxFactory.h"
 #include "CepGen/Modules/ProcessFactory.h"
+#include "CepGen/Modules/RandomGeneratorFactory.h"
 #include "CepGen/Modules/StructureFunctionsFactory.h"
 
 namespace cepgen {
@@ -84,6 +85,7 @@ namespace cepgen {
       list_modules(IntegratorFactory::get(), "Integration algorithms");
       list_modules(AnalyticIntegratorFactory::get(), "Analytic integration algorithms");
       list_modules(DerivatorFactory::get(), "Derivation algorithm");
+      list_modules(RandomGeneratorFactory::get(), "Random number generator engines");
       list_modules(DrawerFactory::get(), "Drawer utilities");
     });
   }

--- a/CepGen/Modules/ModuleFactory.cpp
+++ b/CepGen/Modules/ModuleFactory.cpp
@@ -38,6 +38,7 @@
 #include "CepGen/Utils/Derivator.h"
 #include "CepGen/Utils/Drawer.h"
 #include "CepGen/Utils/Functional.h"
+#include "CepGen/Utils/RandomGenerator.h"
 
 namespace cepgen {
   template <typename T, typename I>
@@ -133,4 +134,5 @@ namespace cepgen {
   template class ModuleFactory<sigrat::Parameterisation, int>;
   template class ModuleFactory<strfun::Parameterisation, int>;
   template class ModuleFactory<utils::Functional, std::string>;
+  template class ModuleFactory<utils::RandomGenerator, std::string>;
 }  // namespace cepgen

--- a/CepGen/Modules/RandomGeneratorFactory.h
+++ b/CepGen/Modules/RandomGeneratorFactory.h
@@ -24,12 +24,12 @@
 /** \file */
 
 /// Add a generic random number generator definition to the list of handled modules
-#define REGISTER_INTEGRATOR(name, obj)                                              \
+#define REGISTER_RANDOM_GENERATOR(name, obj)                                        \
   namespace cepgen {                                                                \
     struct BUILDERNM(obj) {                                                         \
       BUILDERNM(obj)() { RandomGeneratorFactory::get().registerModule<obj>(name); } \
     };                                                                              \
-    static const BUILDERNM(obj) gIntegr##obj;                                       \
+    static const BUILDERNM(obj) gRndGen##obj;                                       \
   }                                                                                 \
   static_assert(true, "")
 

--- a/CepGen/Modules/RandomGeneratorFactory.h
+++ b/CepGen/Modules/RandomGeneratorFactory.h
@@ -1,0 +1,44 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_Modules_RandomGeneratorFactory_h
+#define CepGen_Modules_RandomGeneratorFactory_h
+
+#include "CepGen/Modules/ModuleFactory.h"
+
+/** \file */
+
+/// Add a generic random number generator definition to the list of handled modules
+#define REGISTER_INTEGRATOR(name, obj)                                              \
+  namespace cepgen {                                                                \
+    struct BUILDERNM(obj) {                                                         \
+      BUILDERNM(obj)() { RandomGeneratorFactory::get().registerModule<obj>(name); } \
+    };                                                                              \
+    static const BUILDERNM(obj) gIntegr##obj;                                       \
+  }                                                                                 \
+  static_assert(true, "")
+
+namespace cepgen {
+  namespace utils {
+    class RandomGenerator;
+  }
+  /// A random number generator algorithms factory
+  DEFINE_FACTORY_STR(RandomGeneratorFactory, utils::RandomGenerator, "Random number generator factory");
+}  // namespace cepgen
+
+#endif

--- a/CepGen/Parameters.h
+++ b/CepGen/Parameters.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "CepGen/Physics/Kinematics.h"
+#include "CepGen/Utils/RandomGenerator.h"
 
 namespace cepgen {
   class EventExporter;
@@ -31,8 +32,8 @@ namespace cepgen {
     class Process;
   }
   namespace utils {
-    class TimeKeeper;
     class Functional;
+    class TimeKeeper;
   }  // namespace utils
   enum class IntegratorType;
   /// An ordered collection of event modification algorithms
@@ -206,6 +207,7 @@ namespace cepgen {
     /// A collection of stopwatches for timing
     std::unique_ptr<utils::TimeKeeper> tmr_;
   };
+  static std::unique_ptr<utils::RandomGenerator> gRandomGen;
 }  // namespace cepgen
 
 #endif

--- a/CepGen/Parameters.h
+++ b/CepGen/Parameters.h
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "CepGen/Physics/Kinematics.h"
-#include "CepGen/Utils/RandomGenerator.h"
 
 namespace cepgen {
   class EventExporter;
@@ -207,7 +206,6 @@ namespace cepgen {
     /// A collection of stopwatches for timing
     std::unique_ptr<utils::TimeKeeper> tmr_;
   };
-  static std::unique_ptr<utils::RandomGenerator> gRandomGen;
 }  // namespace cepgen
 
 #endif

--- a/CepGen/Process/Process.cpp
+++ b/CepGen/Process/Process.cpp
@@ -21,17 +21,22 @@
 #include "CepGen/Core/Exception.h"
 #include "CepGen/Event/Event.h"
 #include "CepGen/Modules/CouplingFactory.h"
+#include "CepGen/Modules/RandomGeneratorFactory.h"
 #include "CepGen/Physics/Coupling.h"
 #include "CepGen/Physics/HeavyIon.h"
 #include "CepGen/Physics/PDG.h"
 #include "CepGen/Process/Process.h"
 #include "CepGen/Utils/Math.h"
+#include "CepGen/Utils/RandomGenerator.h"
 #include "CepGen/Utils/String.h"
 
 namespace cepgen {
   namespace proc {
     Process::Process(const ParametersList& params)
-        : NamedModule(params), mp_(PDG::get().mass(PDG::proton)), mp2_(mp_ * mp_) {
+        : NamedModule(params),
+          mp_(PDG::get().mass(PDG::proton)),
+          mp2_(mp_ * mp_),
+          rnd_gen_(RandomGeneratorFactory::get().build(steer<ParametersList>("randomGenerator"))) {
       const auto& kin_params = steer<ParametersList>("kinematics");
       if (!kin_params.empty())
         kinematics().setParameters(kin_params);
@@ -43,6 +48,7 @@ namespace cepgen {
         : NamedModule(proc),
           mp_(PDG::get().mass(PDG::proton)),
           mp2_(mp_ * mp_),
+          rnd_gen_(RandomGeneratorFactory::get().build(proc.rnd_gen_->parameters())),
           s_(proc.s_),
           sqs_(proc.sqs_),
           mA2_(proc.mA2_),
@@ -366,6 +372,8 @@ namespace cepgen {
       desc.add<ParametersDescription>("alphaS", AlphaSFactory::get().describeParameters("pegasus"))
           .setDescription("strong coupling evolution algorithm");
       desc.add<bool>("hasEvent", true).setDescription("does the process carry an event definition");
+      desc.add<ParametersDescription>("randomGenerator", ParametersDescription().setName<std::string>("stl"))
+          .setDescription("random number generator engine");
       return desc;
     }
 

--- a/CepGen/Process/Process.h
+++ b/CepGen/Process/Process.h
@@ -22,13 +22,13 @@
 #include <cstddef>  // size_t
 #include <map>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "CepGen/Event/Particle.h"
 #include "CepGen/Modules/NamedModule.h"
 #include "CepGen/Physics/Coupling.h"
 #include "CepGen/Physics/Kinematics.h"
+#include "CepGen/Utils/RandomGenerator.h"
 
 namespace cepgen {
   class Event;
@@ -159,7 +159,7 @@ namespace cepgen {
       double alphaEM(double q) const;  ///< Compute the electromagnetic running coupling algorithm at a given scale
       double alphaS(double q) const;   ///< Compute the strong coupling algorithm at a given scale
 
-      std::default_random_engine rnd_gen_;  ///< Random number generator engine
+      std::unique_ptr<utils::RandomGenerator> rnd_gen_;  ///< Process-local random number generator engine
 
     private:
       double s_{-1.};    ///< \f$s\f$, squared centre of mass energy of the two-beam system, in \f$\mathrm{GeV}^2\f$

--- a/CepGen/Process/Process2to4.cpp
+++ b/CepGen/Process/Process2to4.cpp
@@ -27,10 +27,7 @@
 namespace cepgen {
   namespace proc {
     Process2to4::Process2to4(const ParametersList& params, pdgid_t cs_id)
-        : FactorisedProcess(params, {cs_id, cs_id}),
-          cs_prop_(PDG::get()(cs_id)),
-          single_limits_(params),
-          rnd_sign_(0, 1) {}
+        : FactorisedProcess(params, {cs_id, cs_id}), cs_prop_(PDG::get()(cs_id)), single_limits_(params) {}
 
     void Process2to4::setCuts(const cuts::Central& single) { single_limits_ = single; }
 
@@ -144,7 +141,7 @@ namespace cepgen {
 
     void Process2to4::fillCentralParticlesKinematics() {
       //--- randomise the charge of outgoing system
-      const short sign = rnd_sign_(rnd_gen_) == 1 ? 1 : -1;
+      const short sign = rnd_gen_->uniformInt(0, 1) == 1 ? 1 : -1;
 
       //--- first outgoing central particle
       auto& oc1 = event()[Particle::CentralSystem][0].get();

--- a/CepGen/Process/Process2to4.h
+++ b/CepGen/Process/Process2to4.h
@@ -59,7 +59,6 @@ namespace cepgen {
       double m_phi_pt_diff_{0.};  ///< Azimuthal angle difference for the two central particles
 
     private:
-      std::uniform_int_distribution<short> rnd_sign_;
       double ww_{0.};
     };
   }  // namespace proc

--- a/CepGen/Utils/GSLRandomGenerator.cpp
+++ b/CepGen/Utils/GSLRandomGenerator.cpp
@@ -1,0 +1,69 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h>
+
+#include <memory>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Utils/RandomGenerator.h"
+
+namespace cepgen {
+  class GSLRandomGenerator : public utils::RandomGenerator {
+  public:
+    explicit GSLRandomGenerator(const ParametersList& params) : utils::RandomGenerator(params) {
+      gsl_rng_env_setup();
+      gsl_rng_type* rng_engine{nullptr};
+      const auto& type = steer<std::string>("type");
+      if (type == "mt19937")
+        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_mt19937);
+      else if (type == "taus2")
+        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_taus2);
+      else if (type == "gfsr4")
+        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_gfsr4);
+      else if (type == "ranlxs0")
+        rng_engine = const_cast<gsl_rng_type*>(gsl_rng_ranlxs0);
+      else
+        throw CG_FATAL("GSLRandomGenerator") << "Random number generator engine not set!";
+
+      rng_.reset(gsl_rng_alloc(rng_engine));
+      gsl_rng_set(rng_.get(), seed_);
+
+      CG_DEBUG("GSLRandomGenerator") << "Random numbers generator: " << gsl_rng_name(rng_.get()) << ".\n\t"
+                                     << "Seed: " << seed_ << ".";
+    }
+
+    int uniformInt(int min, int max) override { return min + gsl_rng_uniform_int(rng_.get(), max - min + 1); }
+
+    double uniform(double min, double max) override { return Limits{min, max}.x(gsl_rng_uniform(rng_.get())); }
+
+    double normal(double mean, double rms) override { return gsl_ran_gaussian(rng_.get(), rms) + mean; }
+
+    double exponential(double exponent) override { return gsl_ran_exponential(rng_.get(), exponent); }
+
+  private:
+    /// A deleter object for GSL's random number generator
+    struct gsl_rng_deleter {
+      /// Destructor method for the random number generator service
+      inline void operator()(gsl_rng* rng) { gsl_rng_free(rng); }
+    };
+    /// Instance of random number generator service
+    std::unique_ptr<gsl_rng, gsl_rng_deleter> rng_;
+  };
+}  // namespace cepgen

--- a/CepGen/Utils/RandomGenerator.cpp
+++ b/CepGen/Utils/RandomGenerator.cpp
@@ -37,6 +37,7 @@ namespace cepgen {
     ParametersDescription RandomGenerator::description() {
       auto desc = ParametersDescription();
       desc.setDescription("unnamed random generator");
+      desc.add<unsigned long long>("seed", time(nullptr)).setDescription("Random number generator seed");
       return desc;
     }
   }  // namespace utils

--- a/CepGen/Utils/RandomGenerator.cpp
+++ b/CepGen/Utils/RandomGenerator.cpp
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "CepGen/Utils/Message.h"
+#include "CepGen/Core/Exception.h"
 #include "CepGen/Utils/RandomGenerator.h"
 
 namespace cepgen {
@@ -28,6 +28,10 @@ namespace cepgen {
       CG_WARNING("RandomGenerator:exponential")
           << "Exponential distribution not implemented for this random number generator.";
       return 0.;
+    }
+
+    void* RandomGenerator::enginePtr() {
+      throw CG_FATAL("RandomGenerator:enginePtr") << "No engine object declared for this random generator.";
     }
 
     ParametersDescription RandomGenerator::description() {

--- a/CepGen/Utils/RandomGenerator.cpp
+++ b/CepGen/Utils/RandomGenerator.cpp
@@ -1,0 +1,39 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Utils/Message.h"
+#include "CepGen/Utils/RandomGenerator.h"
+
+namespace cepgen {
+  namespace utils {
+    RandomGenerator::RandomGenerator(const ParametersList& params)
+        : SteeredObject(params), seed_(steer<unsigned long long>("seed")) {}
+
+    double RandomGenerator::exponential(double /*exponent*/) {
+      CG_WARNING("RandomGenerator:exponential")
+          << "Exponential distribution not implemented for this random number generator.";
+      return 0.;
+    }
+
+    ParametersDescription RandomGenerator::description() {
+      auto desc = ParametersDescription();
+      desc.setDescription("unnamed random generator");
+      return desc;
+    }
+  }  // namespace utils
+}  // namespace cepgen

--- a/CepGen/Utils/RandomGenerator.h
+++ b/CepGen/Utils/RandomGenerator.h
@@ -45,8 +45,15 @@ namespace cepgen {
       // specialised distributions
       virtual double exponential(double exponent = 1.);
 
+      /// Retrieve the engine object
+      template <typename T>
+      T* engine() {
+        return static_cast<T*>(enginePtr());
+      }
+
     protected:
       unsigned long long seed_;
+      virtual void* enginePtr();  ///< engine object
     };
   }  // namespace utils
 }  // namespace cepgen

--- a/CepGen/Utils/RandomGenerator.h
+++ b/CepGen/Utils/RandomGenerator.h
@@ -1,0 +1,54 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_Utils_RandomGenerator_h
+#define CepGen_Utils_RandomGenerator_h
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "CepGen/Core/SteeredObject.h"
+
+namespace cepgen {
+  namespace utils {
+    /// A random number generator
+    /// \author L. Forthomme <laurent.forthomme@cern.ch>
+    /// \date Nov 2023
+    class RandomGenerator : public SteeredObject<RandomGenerator> {
+    public:
+      /// Default constructor
+      explicit RandomGenerator(const ParametersList&);
+
+      static ParametersDescription description();
+
+      // base distributions
+      virtual int uniformInt(int min, int max) = 0;
+      virtual double uniform(double min = 0., double max = 1.) = 0;
+      virtual double normal(double mean = 0., double rms = 1.) = 0;
+
+      // specialised distributions
+      virtual double exponential(double exponent = 1.);
+
+    protected:
+      unsigned long long seed_;
+    };
+  }  // namespace utils
+}  // namespace cepgen
+
+#endif

--- a/CepGen/Utils/STLRandomGenerator.cpp
+++ b/CepGen/Utils/STLRandomGenerator.cpp
@@ -51,7 +51,7 @@ namespace cepgen {
       else if (type == "knuth_b")
         gen_.reset(new Generator<std::knuth_b>(seed));
       else
-        throw CG_FATAL("STLRandomGenerator") << "Random number generator engine not set!";
+        throw CG_FATAL("STLRandomGenerator") << "Random number generator engine invalid: '" << type << "'.";
 
       CG_DEBUG("STLRandomGenerator") << "Random numbers generator with seed: " << seed_ << ".";
     }

--- a/CepGen/Utils/STLRandomGenerator.cpp
+++ b/CepGen/Utils/STLRandomGenerator.cpp
@@ -30,7 +30,13 @@ namespace cepgen {
       std::random_device rd;
       const auto seed = seed_ > 0ull ? seed_ : rd();
       const auto& type = steer<std::string>("type");
-      if (type == "mt19937")
+      if (type == "default")
+        gen_.reset(new Generator<std::default_random_engine>(seed));
+      else if (type == "minstd_rand0")
+        gen_.reset(new Generator<std::minstd_rand0>(seed));
+      else if (type == "minstd_rand")
+        gen_.reset(new Generator<std::minstd_rand>(seed));
+      else if (type == "mt19937")
         gen_.reset(new Generator<std::mt19937>(seed));
       else if (type == "mt19937_64")
         gen_.reset(new Generator<std::mt19937_64>(seed));
@@ -38,6 +44,12 @@ namespace cepgen {
         gen_.reset(new Generator<std::ranlux24_base>(seed));
       else if (type == "ranlux48_base")
         gen_.reset(new Generator<std::ranlux48_base>(seed));
+      else if (type == "ranlux24")
+        gen_.reset(new Generator<std::ranlux24>(seed));
+      else if (type == "ranlux48")
+        gen_.reset(new Generator<std::ranlux48>(seed));
+      else if (type == "knuth_b")
+        gen_.reset(new Generator<std::knuth_b>(seed));
       else
         throw CG_FATAL("STLRandomGenerator") << "Random number generator engine not set!";
 
@@ -47,7 +59,7 @@ namespace cepgen {
     static ParametersDescription description() {
       auto desc = utils::RandomGenerator::description();
       desc.setDescription("STL random number generator engine");
-      desc.add<std::string>("type", "mt19937").setDescription("random number engine");
+      desc.add<std::string>("type", "default").setDescription("random number engine");
       return desc;
     }
 

--- a/CepGen/Utils/STLRandomGenerator.cpp
+++ b/CepGen/Utils/STLRandomGenerator.cpp
@@ -1,0 +1,70 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+#include <random>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Utils/RandomGenerator.h"
+
+namespace cepgen {
+  class STLRandomGenerator : public utils::RandomGenerator {
+  public:
+    explicit STLRandomGenerator(const ParametersList& params) : utils::RandomGenerator(params) {
+      const auto& type = steer<std::string>("type");
+      if (type == "mt19937")
+        rng_.reset(new Generator<std::mt19937>(rd_()));
+      if (!rng_)
+        throw CG_FATAL("STLRandomGenerator") << "Random number generator engine not set!";
+
+      //gsl_rng_set(rng_.get(), seed_);
+
+      CG_DEBUG("STLRandomGenerator") << "Random numbers generator: " << type << ".\n\t"
+                                     << "Seed: " << seed_ << ".";
+    }
+
+    int uniformInt(int min, int max) override { return std::uniform_int_distribution<>(min, max)(*rng_); }
+
+    double uniform(double min, double max) override { return std::uniform_real_distribution<>(min, max)(*rng_); }
+
+    double normal(double mean, double rms) override { return std::normal_distribution<>(mean, rms)(*rng_); }
+
+    double exponential(double exponent) override { return std::exponential_distribution<>(exponent)(*rng_); }
+
+  private:
+    std::random_device rd_;
+    struct GeneratorObject {
+      typedef std::random_device::result_type result_type;
+      //long double operator()() { return 0.; }
+      virtual long double min() = 0;
+      virtual long double max() = 0;
+    };
+    template <typename T>
+    class Generator : public GeneratorObject {
+    public:
+      explicit Generator(std::random_device::result_type rd) : gen_(rd) {}
+      T& operator()() { return gen_; }
+      long double min() override { return gen_.min(); }
+      long double max() override { return gen_.max(); }
+
+    private:
+      T gen_;
+    };
+    std::unique_ptr<GeneratorObject> rng_;
+  };
+}  // namespace cepgen

--- a/CepGenAddOns/CTMLWrapper/utils/cepgenDocGenerator.cc
+++ b/CepGenAddOns/CTMLWrapper/utils/cepgenDocGenerator.cc
@@ -31,6 +31,7 @@
 #include "CepGen/Modules/IntegratorFactory.h"
 #include "CepGen/Modules/PartonFluxFactory.h"
 #include "CepGen/Modules/ProcessFactory.h"
+#include "CepGen/Modules/RandomGeneratorFactory.h"
 #include "CepGen/Modules/StructureFunctionsFactory.h"
 
 namespace cepgen {
@@ -64,6 +65,7 @@ int main(int argc, char* argv[]) {
       .document("alphas", "Strong coupling evolution", cepgen::AlphaSFactory::get())
       .document("integr", "Integrator algorithms", cepgen::IntegratorFactory::get())
       .document("func", "Functional parsers", cepgen::FunctionalFactory::get())
+      .document("rndgen", "Random number generators", cepgen::RandomGeneratorFactory::get())
       .document("drawer", "Drawing tools", cepgen::DrawerFactory::get())
       .document("evtgen", "Event generation algorithms", cepgen::GeneratorWorkerFactory::get())
       .document("evtmod", "Event modification algorithms", cepgen::EventModifierFactory::get())

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaDivonne.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaDivonne.cpp
@@ -72,7 +72,7 @@ namespace cepgen {
             epsrel_,
             epsabs_,
             verbose_,
-            seed_,
+            rnd_gen_->parameters().get<unsigned long long>("seed"),
             mineval_,
             maxeval_,
             key1_,

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaSuave.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaSuave.cpp
@@ -57,7 +57,7 @@ namespace cepgen {
           epsrel_,
           epsabs_,
           verbose_,
-          seed_,
+          rnd_gen_->parameters().get<unsigned long long>("seed"),
           mineval_,
           maxeval_,
           nnew_,

--- a/CepGenAddOns/CubaWrapper/IntegratorCubaVegas.cpp
+++ b/CepGenAddOns/CubaWrapper/IntegratorCubaVegas.cpp
@@ -58,7 +58,7 @@ namespace cepgen {
           epsrel_,
           epsabs_,
           verbose_,
-          seed_,
+          rnd_gen_->parameters().get<unsigned long long>("seed"),
           mineval_,
           maxeval_,
           nstart_,

--- a/CepGenAddOns/Pythia6Wrapper/EventInterface.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/EventInterface.cpp
@@ -23,13 +23,16 @@
 #include "CepGen/Event/Particle.h"
 #include "CepGen/Physics/PDG.h"
 #include "CepGen/Physics/Utils.h"
+#include "CepGen/Utils/RandomGenerator.h"
 #include "CepGen/Utils/String.h"
 #include "CepGenAddOns/Pythia6Wrapper/EventInterface.h"
 #include "CepGenAddOns/Pythia6Wrapper/Pythia6Interface.h"
 
 namespace pythia6 {
-  EventInterface::EventInterface(cepgen::Event& event, const cepgen::mode::Kinematics kin_mode)
-      : evt_(event), rnd_phi_(0., 2. * M_PI), rnd_cos_theta_(-1., 1.), rnd_qdq_(0., 9.) {
+  EventInterface::EventInterface(cepgen::Event& event,
+                                 const cepgen::mode::Kinematics kin_mode,
+                                 cepgen::utils::RandomGenerator* rnd)
+      : evt_(event), rnd_(rnd) {
     if (kin_mode == cepgen::mode::Kinematics::InelasticElastic ||
         kin_mode == cepgen::mode::Kinematics::InelasticInelastic)
       roles_.emplace_back(cepgen::Particle::Role::OutgoingBeam1);
@@ -53,7 +56,7 @@ namespace pythia6 {
       const double mdq = pymass(partons.second), mdq2 = mdq * mdq;
 
       // choose random direction in MX frame
-      const double phi = rnd_phi_(rnd_gen_), theta = acos(rnd_cos_theta_(rnd_gen_));
+      const double phi = rnd_->uniform(0., 2. * M_PI), theta = acos(rnd_->uniform(-1., 1.));
 
       // compute momentum of decay particles from MX
       const double px2 = std::pow(cepgen::utils::energyFromW(part.momentum().mass(), mdq2, mq2), 2) - mq2;
@@ -182,10 +185,10 @@ namespace pythia6 {
   }
 
   std::pair<short, short> EventInterface::pickPartonsContent() {
-    const auto ranudq = rnd_qdq_(rnd_gen_);
-    if (ranudq < 1.)
+    const auto ranudq = rnd_->uniformInt(0, 9);
+    if (ranudq < 1)
       return {cepgen::PDG::down, 2203};  // (d,uu1)
-    if (ranudq < 5.)
+    if (ranudq < 5)
       return {cepgen::PDG::up, 2101};  // (u,ud0)
     return {cepgen::PDG::up, 2103};    // (u,ud1)
   }

--- a/CepGenAddOns/Pythia6Wrapper/EventInterface.h
+++ b/CepGenAddOns/Pythia6Wrapper/EventInterface.h
@@ -19,19 +19,21 @@
 #ifndef CepGenAddOns_Pythia6Wrapper_EventInterface_h
 #define CepGenAddOns_Pythia6Wrapper_EventInterface_h
 
-#include <random>
 #include <vector>
 
 #include "CepGen/Physics/Modes.h"
 
 namespace cepgen {
   class Event;
-}
+  namespace utils {
+    class RandomGenerator;
+  }
+}  // namespace cepgen
 namespace pythia6 {
   /// Interface to the Pythia 6 event content.
   class EventInterface {
   public:
-    explicit EventInterface(cepgen::Event&, cepgen::mode::Kinematics);
+    explicit EventInterface(cepgen::Event&, cepgen::mode::Kinematics, cepgen::utils::RandomGenerator*);
 
     void prepareHadronisation();
     size_t numStrings() const { return evt_strings_.size(); }
@@ -40,11 +42,9 @@ namespace pythia6 {
   private:
     void fillEventBlock();
 
-    cepgen::Event& evt_;  // NOT owning
+    cepgen::Event& evt_;                   // NOT owning
+    cepgen::utils::RandomGenerator* rnd_;  ///< Random number generator engine (not owning)
     std::vector<cepgen::Particle::Role> roles_;
-
-    std::default_random_engine rnd_gen_;  ///< Random number generator engine
-    std::uniform_real_distribution<double> rnd_phi_, rnd_cos_theta_, rnd_qdq_;
 
     std::pair<short, short> pickPartonsContent();
 

--- a/CepGenAddOns/Pythia6Wrapper/Pythia6Hadroniser.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/Pythia6Hadroniser.cpp
@@ -22,6 +22,7 @@
 #include "CepGen/Modules/RandomGeneratorFactory.h"
 #include "CepGen/Parameters.h"
 #include "CepGen/Physics/Hadroniser.h"
+#include "CepGen/Utils/RandomGenerator.h"
 #include "CepGen/Utils/String.h"
 #include "CepGenAddOns/Pythia6Wrapper/EventInterface.h"
 #include "CepGenAddOns/Pythia6Wrapper/Pythia6Interface.h"

--- a/CepGenAddOns/Pythia6Wrapper/Pythia6Hadroniser.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/Pythia6Hadroniser.cpp
@@ -41,7 +41,7 @@ namespace cepgen {
       static inline ParametersDescription description() {
         auto desc = Hadroniser::description();
         desc.setDescription("Interface to the Pythia 6 string hadronisation/fragmentation algorithm");
-        desc.add<ParametersDescription>("randomGenerator", ParametersDescription().setName<std::string>("stl:mt19937"))
+        desc.add<ParametersDescription>("randomGenerator", ParametersDescription().setName<std::string>("stl"))
             .setDescription("random number generator to use for the various intermediate computations");
         return desc;
       }

--- a/CepGenAddOns/Pythia8Wrapper/test/lhe_writer.cc
+++ b/CepGenAddOns/Pythia8Wrapper/test/lhe_writer.cc
@@ -1,11 +1,12 @@
 #include <fstream>
-#include <random>
 
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/Generator.h"
 #include "CepGen/Modules/EventExporterFactory.h"
+#include "CepGen/Modules/RandomGeneratorFactory.h"
 #include "CepGen/Utils/ArgumentsParser.h"
 #include "CepGen/Utils/Filesystem.h"
+#include "CepGen/Utils/RandomGenerator.h"
 #include "CepGen/Utils/Test.h"
 
 using namespace std;
@@ -24,10 +25,8 @@ int main(int argc, char* argv[]) {
       "lhef", cepgen::ParametersList().set<std::string>("filename", output_file));
 
   // randomise the number of events to be written in the output file
-  random_device rand;
-  mt19937 gen(rand());
-  uniform_int_distribution<> dis(1, 10);
-  const size_t num_events = dis(gen);
+  auto rng = cepgen::RandomGeneratorFactory::get().build("stl");
+  const size_t num_events = rng->uniformInt(1, 10);
 
   // generate one simple event
   auto evt = cepgen::Event::minimal();

--- a/CepGenAddOns/ROOTWrapper/CMakeLists.txt
+++ b/CepGenAddOns/ROOTWrapper/CMakeLists.txt
@@ -9,12 +9,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 set(sources IntegratorROOT.cpp
+            ROOTAnalyticalIntegrator.cpp
             ROOTDerivator.cpp
             ROOTDrawer.cpp
-            ROOTTree*.cpp
-            ROOTHistsHandler.cpp
             ROOTFunctional.cpp
-            ROOTAnalyticalIntegrator.cpp)
+            ROOTHistsHandler.cpp
+            ROOTRandomGenerator.cpp
+            ROOTTree*.cpp)
 
 #--- FOAM integrator
 if(CMAKE_BUILD_FOAM)

--- a/CepGenAddOns/ROOTWrapper/IntegratorFoam.cpp
+++ b/CepGenAddOns/ROOTWrapper/IntegratorFoam.cpp
@@ -65,7 +65,7 @@ namespace cepgen {
       rnd_.reset(new TRandom3);
     else
       throw CG_FATAL("IntegratorFoam") << "Unrecognised random generator: \"" << rnd_mode << "\".";
-    rnd_->SetSeed(seed_);
+    rnd_->SetSeed(rnd_gen_->parameters().get<unsigned long long>("seed"));
 
     //--- a bit of printout for debugging
     CG_DEBUG("Integrator:build") << "FOAM integrator built\n\t"

--- a/CepGenAddOns/ROOTWrapper/ROOTRandomGenerator.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTRandomGenerator.cpp
@@ -1,0 +1,73 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <TRandom1.h>
+#include <TRandom2.h>
+#include <TRandom3.h>
+#include <TRandomGen.h>
+
+#include <memory>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Modules/RandomGeneratorFactory.h"
+#include "CepGen/Utils/RandomGenerator.h"
+
+namespace cepgen {
+  class ROOTRandomGenerator : public utils::RandomGenerator {
+  public:
+    explicit ROOTRandomGenerator(const ParametersList& params) : utils::RandomGenerator(params) {
+      const auto& type = steer<std::string>("type");
+      if (type == "Ranlux")
+        rng_.reset(new TRandom1);
+      else if (type == "Tausworthe")
+        rng_.reset(new TRandom2);
+      else if (type == "MersenneTwister")
+        rng_.reset(new TRandom3);
+      else if (type == "Ranlux")
+        rng_.reset(new TRandomRanluxpp);
+      else if (type == "MixMax")
+        rng_.reset(new TRandomMixMax);
+      else if (type == "MixMax17")
+        rng_.reset(new TRandomMixMax17);
+      else if (type == "MixMax256")
+        rng_.reset(new TRandomMixMax256);
+      else
+        throw CG_FATAL("ROOTRandomGenerator") << "Random number generator engine invalid: '" << type << "'.";
+
+      rng_->SetSeed(seed_);
+    }
+
+    static ParametersDescription description() {
+      auto desc = utils::RandomGenerator::description();
+      desc.setDescription("ROOT random number generator engine");
+      desc.add<std::string>("type", "Ranlux").setDescription("random number engine");
+      return desc;
+    }
+
+    int uniformInt(int min, int max) override { return min + rng_->Integer(max - min + 1); }
+    double uniform(double min, double max) override { return rng_->Uniform(min, max); }
+    double normal(double mean, double rms) override { return rng_->Gaus(mean, rms); }
+    double exponential(double exponent) override { return rng_->Exp(exponent); }
+
+  private:
+    void* enginePtr() override { return rng_.get(); }
+    std::unique_ptr<TRandom> rng_;
+  };
+}  // namespace cepgen
+
+REGISTER_RANDOM_GENERATOR("root", ROOTRandomGenerator);

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -61,17 +61,10 @@ public:
       : proc::Process(params),
         opt_(steer<int>("nopt")),
         pair_(steer<ParticleProperties>("pair")),
-        symmetrise_(steer<bool>("symmetrise")),
-        rnd_phi_(0., 2. * M_PI),
-        rnd_side_(0, 1) {}
+        symmetrise_(steer<bool>("symmetrise")) {}
 
   explicit LPAIR(const LPAIR& oth)
-      : proc::Process(oth),
-        opt_(oth.opt_),
-        pair_(oth.pair_),
-        symmetrise_(oth.symmetrise_),
-        rnd_phi_(oth.rnd_phi_),
-        rnd_side_(oth.rnd_side_) {}
+      : proc::Process(oth), opt_(oth.opt_), pair_(oth.pair_), symmetrise_(oth.symmetrise_) {}
   /// Copy constructor
   proc::ProcessPtr clone() const override { return proc::ProcessPtr(new LPAIR(*this)); }
 
@@ -234,8 +227,6 @@ private:
     const double ax = std::sqrt(std::pow(out - y - z, 2) + c);
     return {out, ax * log(yy)};
   }
-  std::uniform_real_distribution<double> rnd_phi_;
-  std::uniform_int_distribution<short> rnd_side_;
   std::unique_ptr<formfac::Parameterisation> formfac_;
   std::unique_ptr<strfun::Parameterisation> strfun_;
 };
@@ -927,9 +918,9 @@ double LPAIR::computeWeight() {
 
 void LPAIR::fillKinematics(bool) {
   //----- parameterise a random rotation around z-axis
-  const short rany = rnd_side_(rnd_gen_) == 1 ? 1 : -1, ransign = rnd_side_(rnd_gen_) == 1 ? 1 : -1;
-  const double ranphi = rnd_phi_(rnd_gen_);
-  const short ranz = symmetrise_ ? (rnd_side_(rnd_gen_) == 1 ? 1 : -1) : 1;
+  const short rany = rnd_gen_->uniformInt(0, 1) == 1 ? 1 : -1, ransign = rnd_gen_->uniformInt(0, 1) == 1 ? 1 : -1;
+  const double ranphi = rnd_gen_->uniform(0., 2. * M_PI);
+  const short ranz = symmetrise_ ? (rnd_gen_->uniformInt(0, 1) == 1 ? 1 : -1) : 1;
 
   //----- incoming beams
   pA() = Momentum(0., 0., +p_cm_, ep1_).betaGammaBoost(boost_props_.gamma, boost_props_.betgam);

--- a/src/utils/cepgenDescribeModules.cc
+++ b/src/utils/cepgenDescribeModules.cc
@@ -35,6 +35,7 @@
 #include "CepGen/Modules/IntegratorFactory.h"
 #include "CepGen/Modules/PartonFluxFactory.h"
 #include "CepGen/Modules/ProcessFactory.h"
+#include "CepGen/Modules/RandomGeneratorFactory.h"
 #include "CepGen/Modules/StructureFunctionsFactory.h"
 
 using namespace std;
@@ -141,6 +142,7 @@ int main(int argc, char* argv[]) {
     LOOP_FACTORY("Integrator", cepgen::IntegratorFactory);
     LOOP_FACTORY("Analytic integrator", cepgen::AnalyticIntegratorFactory);
     LOOP_FACTORY("Derivator", cepgen::DerivatorFactory);
+    LOOP_FACTORY("Random generator", cepgen::RandomGeneratorFactory);
     LOOP_FACTORY("Drawer", cepgen::DrawerFactory);
     CG_LOG << os.str();
     return 0;


### PR DESCRIPTION
A new `cepgen::utils::RandomGenerator` object is introduced and designed to replace the standard STL/GSL random number generator engines.