### PR TITLE
Process debugging helper

### DIFF
--- a/CepGen/Integration/Integrand.h
+++ b/CepGen/Integration/Integrand.h
@@ -33,6 +33,8 @@ namespace cepgen {
     virtual double eval(const std::vector<double>&) = 0;
     /// Phase space dimension
     virtual size_t size() const = 0;
+    /// Does this integrand also contain a process object?
+    virtual bool hasProcess() const { return false; }
   };
 }  // namespace cepgen
 

--- a/CepGen/Integration/IntegratorVegas.cpp
+++ b/CepGen/Integration/IntegratorVegas.cpp
@@ -22,6 +22,7 @@
 #include "CepGen/Integration/Integrand.h"
 #include "CepGen/Integration/IntegratorGSL.h"
 #include "CepGen/Modules/IntegratorFactory.h"
+#include "CepGen/Utils/ProcessVariablesAnalyser.h"
 #include "CepGen/Utils/String.h"
 
 namespace cepgen {

--- a/CepGen/Integration/ProcessIntegrand.h
+++ b/CepGen/Integration/ProcessIntegrand.h
@@ -49,6 +49,7 @@ namespace cepgen {
     ///  \f$\forall i=1,\ldots,N\f$, \f$0<x_i<1\f$).
     double eval(const std::vector<double>& x) override;
     size_t size() const override;  ///< Phase space dimension
+    bool hasProcess() const override final { return true; }
 
     proc::Process& process();              ///< Thread-local physics process
     const proc::Process& process() const;  ///< Thread-local physics process

--- a/CepGen/Process/Process.h
+++ b/CepGen/Process/Process.h
@@ -28,6 +28,7 @@
 #include "CepGen/Modules/NamedModule.h"
 #include "CepGen/Physics/Coupling.h"
 #include "CepGen/Physics/Kinematics.h"
+#include "CepGen/Utils/ProcessVariablesAnalyser.h"
 #include "CepGen/Utils/RandomGenerator.h"
 
 namespace cepgen {

--- a/CepGen/Process/Process.h
+++ b/CepGen/Process/Process.h
@@ -202,6 +202,7 @@ namespace cepgen {
       double base_jacobian_{1.};
       Kinematics kin_{ParametersList()};  ///< Set of cuts to apply on the final phase space
       std::unique_ptr<Event> event_;      ///< Event object tracking all information on all particles in the system
+      friend class utils::ProcessVariablesAnalyser;
     };
     /// Helper typedef for a Process unique pointer
     typedef std::unique_ptr<Process> ProcessPtr;

--- a/CepGen/Utils/ProcessVariablesAnalyser.cpp
+++ b/CepGen/Utils/ProcessVariablesAnalyser.cpp
@@ -1,0 +1,64 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Process/Process.h"
+#include "CepGen/Utils/Message.h"
+#include "CepGen/Utils/ProcessVariablesAnalyser.h"
+
+namespace cepgen {
+  namespace utils {
+    ProcessVariablesAnalyser::ProcessVariablesAnalyser(const ParametersList& params) : SteeredObject(params) {}
+
+    ProcessVariablesAnalyser& ProcessVariablesAnalyser::get(const ParametersList& params) {
+      static ProcessVariablesAnalyser analyser(params);
+      return analyser;
+    }
+
+    void ProcessVariablesAnalyser::reset(const proc::Process& proc) {
+      hists_.clear();
+      for (const auto& var : proc.mapped_variables_) {
+        if (const auto& hist = steer<ParametersList>(var.name); !hist.empty()) {
+          if (const auto& xbins = hist.get<std::vector<double> >("xbins"); xbins.size() > 1)
+            hists_.insert(std::make_pair(var.name, Hist1D(xbins, var.name)));
+          else if (hist.get<Limits>("xrange").valid()) {
+            const auto& nbins = (hist.get<int>("nbins") > 0 ? hist.get<int>("nbins") : hist.get<int>("nbinsX"));
+            hists_.insert(std::make_pair(var.name, Hist1D(nbins, hist.get<Limits>("xrange"), var.name)));
+          }
+        }
+      }
+    }
+
+    void ProcessVariablesAnalyser::analyse(proc::Process& proc, double weight) {
+      for (const auto& var : proc.mapped_variables_) {
+        if (hists_.count(var.name))
+          hists_.at(var.name).fill(var.value, weight);
+      }
+    }
+
+    ParametersDescription ProcessVariablesAnalyser::description() {
+      auto desc = ParametersDescription();
+      ParametersDescription hist_desc;
+      hist_desc.add<std::vector<double> >("xbins", {}).setDescription("x-axis bins definition");
+      hist_desc.add<int>("nbins", 25).setDescription("Bins multiplicity for x-axis");
+      hist_desc.add<int>("nbinsX", -1).setDescription("Bins multiplicity for x-axis");
+      hist_desc.add<Limits>("xrange", Limits{0., 1.}).setDescription("Minimum-maximum range for x-axis");
+      desc.addParametersDescriptionVector("histVariables", hist_desc, {}).setDescription("Histogram definition");
+      return desc;
+    }
+  }  // namespace utils
+}  // namespace cepgen

--- a/CepGen/Utils/ProcessVariablesAnalyser.h
+++ b/CepGen/Utils/ProcessVariablesAnalyser.h
@@ -1,0 +1,45 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_Utils_ProcessVariablesAnalyser_h
+#define CepGen_Utils_ProcessVariablesAnalyser_h
+
+#include "CepGen/Core/SteeredObject.h"
+#include "CepGen/Utils/Histogram.h"
+
+namespace cepgen {
+  namespace proc {
+    class Process;
+  }
+  namespace utils {
+    class ProcessVariablesAnalyser : public SteeredObject<ProcessVariablesAnalyser> {
+    public:
+      static ProcessVariablesAnalyser& get(const ParametersList& = ParametersList());
+      static ParametersDescription description();
+
+      void reset(const proc::Process&);
+      void analyse(proc::Process&, double weight);
+
+    private:
+      explicit ProcessVariablesAnalyser(const ParametersList&);
+      std::unordered_map<std::string, Hist1D> hists_;
+    };
+  }  // namespace utils
+}  // namespace cepgen
+
+#endif

--- a/CepGen/Utils/ProcessVariablesAnalyser.h
+++ b/CepGen/Utils/ProcessVariablesAnalyser.h
@@ -27,16 +27,19 @@ namespace cepgen {
     class Process;
   }
   namespace utils {
+    class Drawer;
     class ProcessVariablesAnalyser : public SteeredObject<ProcessVariablesAnalyser> {
     public:
-      static ProcessVariablesAnalyser& get(const ParametersList& = ParametersList());
+      explicit ProcessVariablesAnalyser(const proc::Process&, const ParametersList&);
+
       static ParametersDescription description();
 
-      void reset(const proc::Process&);
-      void analyse(proc::Process&, double weight);
+      void feed(double weight);
+      void analyse();
 
     private:
-      explicit ProcessVariablesAnalyser(const ParametersList&);
+      const proc::Process& proc_;
+      const std::unique_ptr<Drawer> drawer_;
       std::unordered_map<std::string, Hist1D> hists_;
     };
   }  // namespace utils


### PR DESCRIPTION
This PR introduces a new process investigation procedure (currently only available with Foam) to generate weighted distributions of all integration variables.

This requires the integrand to be carrying a process object, thus the generic integrand base class is providing this attribute.