### PR TITLE
Utils: added GSL wrappers to matrices/vectors

### DIFF
--- a/CepGen/Utils/Algebra.cpp
+++ b/CepGen/Utils/Algebra.cpp
@@ -1,0 +1,329 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2020-2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gsl/gsl_blas.h>
+#include <gsl/gsl_linalg.h>
+
+#include <string>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Utils/Algebra.h"
+
+namespace cepgen {
+  typedef std::unique_ptr<gsl_permutation, void (*)(gsl_permutation*)> Permutation;
+
+  Matrix::Matrix(size_t num_rows, size_t num_cols) : gsl_mat_(gsl_matrix_alloc(num_rows, num_cols), gsl_matrix_free) {}
+
+  Matrix::Matrix(const std::initializer_list<Vector>& mat)
+      : gsl_mat_(gsl_matrix_alloc(mat.size(), mat.begin()->size()), gsl_matrix_free) {
+    if (mat.size() == 0)
+      return;
+
+    size_t ix = 0;
+    for (const auto& line : mat) {
+      if (line.size() != numColumns())
+        throw CG_FATAL("Matrix") << "Invalid initialiser; all lines must have the same number of elements!";
+      for (size_t iy = 0; iy < line.size(); ++iy)
+        operator()(ix, iy) = line(iy);
+      ++ix;
+    }
+  }
+
+  Matrix::Matrix(const Matrix& oth) : gsl_mat_(gsl_matrix_alloc(oth.numRows(), oth.numColumns()), gsl_matrix_free) {
+    if (gsl_matrix_memcpy(gsl_mat_.get(), oth.gsl_mat_.get()) != 0)
+      throw CG_FATAL("Matrix") << "Failed to clone a matrix!";
+  }
+
+  Matrix& Matrix::operator=(const Matrix& oth) {
+    gsl_mat_.reset(gsl_matrix_alloc(oth.numRows(), oth.numColumns()));
+    if (gsl_matrix_memcpy(gsl_mat_.get(), oth.gsl_mat_.get()) != 0)
+      throw CG_FATAL("Matrix") << "Failed to clone a matrix!";
+    return *this;
+  }
+
+  Matrix::operator Vector() const {
+    if (numRows() == 1)
+      return row(0);
+    if (numColumns() == 1)
+      return column(0);
+    throw CG_FATAL("Matrix:Vector") << "Only 1xN matrices can be converted to vectors.";
+  }
+
+  Matrix Matrix::zero(size_t num_rows, size_t num_cols) {
+    if (num_cols == 0ull)
+      num_cols = num_rows;
+    Matrix out(num_rows, num_cols);
+    gsl_matrix_set_zero(out.gsl_mat_.get());
+    return out;
+  }
+
+  Matrix Matrix::uniform(size_t num_rows, size_t num_cols, double value) {
+    Matrix out(num_rows, num_cols);
+    gsl_matrix_set_all(out.gsl_mat_.get(), value);
+    return out;
+  }
+
+  Matrix Matrix::identity(size_t n) {
+    Matrix out(n, n);
+    gsl_matrix_set_identity(out.gsl_mat_.get());
+    return out;
+  }
+
+  Matrix Matrix::diagonal(const Vector& vec) {
+    auto out = Matrix::uniform(vec.size(), vec.size(), 0.);
+    for (size_t i = 0; i < vec.size(); ++i)
+      out(i, i) = vec(i);
+    return out;
+  }
+
+  size_t Matrix::numColumns() const { return gsl_mat_->size2; }
+
+  size_t Matrix::numRows() const { return gsl_mat_->size1; }
+
+  Matrix Matrix::subset(size_t min_y, size_t min_x, size_t max_y, size_t max_x) const {
+    const size_t num_x = max_x - min_y, num_y = max_y - min_y;
+    Matrix out(num_y, num_x);
+    gsl_matrix_const_submatrix(out.gsl_mat_.get(), min_y, min_x, num_y, num_x);
+    return out;
+  }
+
+  bool Matrix::operator==(const Matrix& oth) const { return gsl_matrix_equal(gsl_mat_.get(), oth.gsl_mat_.get()) == 1; }
+
+  Matrix& Matrix::operator*=(double val) {
+    *this = *this * val;
+    return *this;
+  }
+
+  Matrix& Matrix::operator*=(const Vector& vec) {
+    *this = *this * vec;
+    return *this;
+  }
+
+  Matrix& Matrix::operator*=(const Matrix& mat) {
+    *this = *this * mat;
+    return *this;
+  }
+
+  Matrix Matrix::operator-() const { return Matrix::zero(numRows(), numColumns()) - *this; }
+
+  Matrix& Matrix::operator+=(const Matrix& oth) {
+    *this = *this + oth;
+    return *this;
+  }
+
+  Matrix& Matrix::operator-=(const Matrix& oth) {
+    *this = *this - oth;
+    return *this;
+  }
+
+  Vector Matrix::operator%(const Vector& vec) const {
+    Matrix cpy(*this);
+    Permutation perm(gsl_permutation_alloc(vec.size()), gsl_permutation_free);
+    gsl_vector_view vec_v = gsl_matrix_column(vec.gsl_mat_.get(), 0);
+    int s;
+    gsl_linalg_LU_decomp(cpy.gsl_mat_.get(), perm.get(), &s);
+    std::vector<double> out(vec.size(), 0.);
+    gsl_vector_view res_v = gsl_vector_view_array(out.data(), out.size());
+    gsl_linalg_LU_solve(cpy.gsl_mat_.get(), perm.get(), &vec_v.vector, &res_v.vector);
+    return res_v;
+  }
+
+  double& Matrix::operator()(size_t ix, size_t iy) {
+    if (ix >= numRows() || iy >= numColumns())
+      throw CG_ERROR("Matrix:operator()")
+          << "Invalid coordinates for " << numColumns() << "*" << numRows() << " matrix: (" << ix << ", " << iy << ").";
+    return *gsl_matrix_ptr(gsl_mat_.get(), ix, iy);
+  }
+
+  double Matrix::operator()(size_t ix, size_t iy) const {
+    if (ix >= numRows() || iy >= numColumns())
+      throw CG_ERROR("Matrix:operator()")
+          << "Invalid coordinates for " << numColumns() << "*" << numRows() << " matrix: (" << ix << ", " << iy << ").";
+    return gsl_matrix_get(gsl_mat_.get(), ix, iy);
+  }
+
+  Matrix::Indices Matrix::imin() const {
+    size_t imax, jmax;
+    gsl_matrix_min_index(gsl_mat_.get(), &imax, &jmax);
+    return std::make_pair(imax, jmax);
+  }
+
+  Matrix::Indices Matrix::imax() const {
+    size_t imax, jmax;
+    gsl_matrix_max_index(gsl_mat_.get(), &imax, &jmax);
+    return std::make_pair(imax, jmax);
+  }
+
+  double Matrix::min() const { return gsl_matrix_min(gsl_mat_.get()); }
+
+  double Matrix::max() const { return gsl_matrix_max(gsl_mat_.get()); }
+
+  bool Matrix::null() const { return gsl_matrix_isnull(gsl_mat_.get()) == 1; }
+
+  bool Matrix::positive() const { return gsl_matrix_ispos(gsl_mat_.get()) == 1; }
+
+  bool Matrix::negative() const { return gsl_matrix_isneg(gsl_mat_.get()) == 1; }
+
+  bool Matrix::nonNegative() const { return gsl_matrix_isnonneg(gsl_mat_.get()) == 1; }
+
+  Matrix& Matrix::truncate(double min) {
+    for (size_t iy = 0; iy < numRows(); ++iy)
+      for (size_t ix = 0; ix < numColumns(); ++ix) {
+        auto& val = operator()(iy, ix);
+        if (val < min)
+          val = 0.;
+      }
+    return *this;
+  }
+
+  Matrix& Matrix::transpose() {
+    //gsl_matrix_transpose(gsl_mat_.get()); // only works for square matrices in GSL
+    auto transp = Matrix(numColumns(), numRows());
+    for (size_t ix = 0; ix < numRows(); ++ix)
+      for (size_t iy = 0; iy < numColumns(); ++iy)
+        transp(iy, ix) = operator()(ix, iy);
+    *this = transp;
+    return *this;
+  }
+
+  Matrix Matrix::transposed() const { return Matrix(*this).transpose(); }
+
+  Matrix& Matrix::invert() {
+    if (numRows() != numColumns()) {
+      CG_WARNING("Matrix:inverted") << "Matrix inversion only works on square matrices.";
+      return *this;
+    }
+    Matrix cpy(*this);
+    Permutation perm(gsl_permutation_alloc(numRows()), gsl_permutation_free);
+    int s;
+    gsl_linalg_LU_decomp(cpy.gsl_mat_.get(), perm.get(), &s);
+    gsl_linalg_LU_invert(cpy.gsl_mat_.get(), perm.get(), gsl_mat_.get());
+    return *this;
+  }
+
+  Matrix Matrix::inverted() const { return Matrix(*this).invert(); }
+
+  Vector Matrix::column(size_t i) const { return gsl_matrix_column(gsl_mat_.get(), i); }
+
+  Vector Matrix::row(size_t i) const { return gsl_matrix_row(gsl_mat_.get(), i); }
+
+  Vector Matrix::diagonal() const { return gsl_matrix_diagonal(gsl_mat_.get()); }
+
+  //--- friend operators
+
+  Matrix operator+(const Matrix& lhs, const Matrix& rhs) {
+    Matrix out(lhs);
+    gsl_matrix_add(out.gsl_mat_.get(), rhs.gsl_mat_.get());
+    return out;
+  }
+
+  Matrix operator-(const Matrix& lhs, const Matrix& rhs) {
+    Matrix out(lhs);
+    gsl_matrix_sub(out.gsl_mat_.get(), rhs.gsl_mat_.get());
+    return out;
+  }
+
+  Matrix operator*(double val, const Matrix& lhs) {
+    Matrix out(lhs);
+    gsl_matrix_scale(out.gsl_mat_.get(), val);
+    return out;
+  }
+
+  Matrix operator*(const Matrix& lhs, double val) {
+    Matrix out(lhs);
+    gsl_matrix_scale(out.gsl_mat_.get(), val);
+    return out;
+  }
+
+  Vector operator*(const Matrix& mat, const Vector& vec) {
+    gsl_vector_view vec_v = gsl_matrix_column(vec.gsl_mat_.get(), 0);
+    std::vector<double> out(mat.numRows(), 0.);
+    gsl_vector_view res_v = gsl_vector_view_array(out.data(), out.size());
+    gsl_blas_dgemv(CblasNoTrans, 1., mat.gsl_mat_.get(), &vec_v.vector, 0., &res_v.vector);
+    return res_v;
+  }
+
+  Matrix operator*(const Matrix& mat1, const Matrix& mat2) {
+    Matrix out(mat1.numRows(), mat2.numColumns());
+    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1., mat1.gsl_mat_.get(), mat2.gsl_mat_.get(), 0., out.gsl_mat_.get());
+    return out;
+  }
+
+  std::ostream& operator<<(std::ostream& os, const Matrix& mat) {
+    os << "(";
+    std::string sep;
+    for (size_t i = 0; i < mat.numRows(); ++i)
+      os << sep << mat.row(i), sep = "\n ";
+    return os << ")";
+  }
+
+  //---------------------------------------------------------------------------
+
+  Vector::Vector(size_t num_coord, double def) : Matrix(Matrix::uniform(num_coord, 1, def)) {}
+
+  Vector::Vector(const std::initializer_list<double>& vec) : Matrix(vec.size(), 1) {
+    size_t i = 0;
+    for (const auto& elem : vec)
+      operator()(i++) = elem;
+  }
+
+  Vector::Vector(const gsl_vector_view& vec) : Matrix(vec.vector.size, 1) {
+    for (size_t i = 0; i < vec.vector.size; ++i)
+      Matrix::operator()(i, 0) = gsl_vector_get(&vec.vector, i);
+  }
+
+  size_t Vector::size() const { return Matrix::numRows(); }
+
+  Vector Vector::subset(size_t min, size_t max) const { return Matrix::subset(min, 0, max, 0).column(0); }
+
+  double& Vector::operator()(size_t i) { return Matrix::operator()(i, 0); }
+
+  double Vector::operator()(size_t i) const { return Matrix::operator()(i, 0); }
+
+  double Vector::dot(const Vector& oth) const {
+    if (size() != oth.size()) {
+      CG_WARNING("Vector:scalarproduct") << "Scalar product of two vectors only defined "
+                                         << "for same-length vectors.";
+      return 0.;
+    }
+    double out = 0.;
+    for (size_t i = 0; i < size(); ++i)
+      out += operator()(i) * oth(i);
+    return out;
+  }
+
+  Vector Vector::cross(const Vector& oth) const {
+    if (size() != oth.size())
+      throw CG_FATAL("Vector:vectorproduct") << "Vector/cross product of two vectors only defined "
+                                             << "for same-length vectors.";
+    if (oth.size() != 3)
+      throw CG_FATAL("Vector:vectorproduct") << "Vector product only implemented for 3-vectors.";
+    //FIXME extend to N-dimensional vectors
+    return Vector{(operator()(1) * oth(2) - operator()(2) * oth(1)),
+                  (operator()(2) * oth(0) - operator()(0) * oth(2)),
+                  (operator()(0) * oth(1) - operator()(1) * oth(0))};
+  }
+
+  std::ostream& operator<<(std::ostream& os, const Vector& vec) {
+    os << "(";
+    std::string sep;
+    for (size_t i = 0; i < vec.size(); ++i)
+      os << sep << vec(i), sep = ", ";
+    return os << ")";
+  }
+}  // namespace cepgen

--- a/CepGen/Utils/Algebra.h
+++ b/CepGen/Utils/Algebra.h
@@ -117,16 +117,19 @@ namespace cepgen {
     std::unique_ptr<gsl_matrix, void (*)(gsl_matrix*)> gsl_mat_;
   };
 
-  class VectorRef {
+  class VectorRef : public gsl_vector_view {
   public:
     VectorRef(const gsl_vector_view&);
 
-    VectorRef& operator=(const Vector&);  ///< Assignment operator
-    double& operator()(size_t);           ///< Component access operator
-    double operator()(size_t) const;      ///< Component retrieval operator
+    VectorRef& operator=(const Vector&);                                          ///< Assignment operator
+    operator Vector() const;                                                      ///< Conversion operator to a vector
+    bool operator==(const Vector&) const;                                         ///< Equality with a vector operator
+    inline bool operator!=(const Vector& vec) const { return !operator==(vec); }  ///< Inequality with a vector operator
+    double& operator()(size_t);                                                   ///< Component access operator
+    double operator()(size_t) const;                                              ///< Component retrieval operator
+    friend std::ostream& operator<<(std::ostream&, const VectorRef&);             ///< Printout operator
 
   private:
-    gsl_vector_view& view_;
     friend class Vector;
   };
 

--- a/CepGen/Utils/Algebra.h
+++ b/CepGen/Utils/Algebra.h
@@ -1,0 +1,142 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2020-2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_Utils_Algebra_h
+#define CepGen_Utils_Algebra_h
+
+#include <gsl/gsl_matrix_double.h>
+
+#include <initializer_list>
+#include <memory>
+
+namespace cepgen {
+  struct Vector;
+  /// A \f$n\times m\f$ matrix object
+  class Matrix {
+  public:
+    /// Object constructor
+    /// \param[in] num_rows number of (horizontal) rows for the matrix
+    /// \param[in] num_cols number of (vertical) columns for the matrix
+    explicit Matrix(size_t num_rows, size_t num_cols);
+    /// Object constructor (from vectors)
+    /// \param[in] vecs set of (vector) rows
+    Matrix(const std::initializer_list<Vector>& vecs);
+
+    Matrix(const Matrix&);             ///< Copy constructor
+    Matrix& operator=(const Matrix&);  ///< Assignment operator
+    operator Vector() const;           ///< Implicit conversion to vector
+
+    /// Build a zero'ed matrix
+    /// \param[in] num_rows number of (horizontal) rows for the matrix
+    /// \param[in] num_cols number of (vertical) columns for the matrix
+    static Matrix zero(size_t num_rows, size_t num_cols = 0ull);
+    /// Build a uniform matrix
+    /// \param[in] num_rows number of (horizontal) rows for the matrix
+    /// \param[in] num_cols number of (vertical) columns for the matrix
+    /// \param[in] value uniform value for all the matrix components
+    static Matrix uniform(size_t num_rows, size_t num_cols, double value = 1.);
+    static Matrix identity(size_t);         ///< Build a (square) identity matrix
+    static Matrix diagonal(const Vector&);  ///< Build a (square) diagonal matrix from its diagonal vector
+
+    size_t numColumns() const;  ///< Number of (vertical) columns
+    size_t numRows() const;     ///< Number of (horizontal) rows
+
+    bool operator==(const Matrix&) const;                                           ///< Equality operator
+    inline bool operator!=(const Matrix& oth) const { return !(operator==(oth)); }  ///< Inequality operator
+
+    /// Extract a subset of the matrix as a new object
+    /// \param[in] min_y first vertical index for the subset
+    /// \param[in] min_x first horizontal index for the subset
+    /// \param[in] max_y last vertical index for the subset
+    /// \param[in] max_x last horizontal index for the subset
+    Matrix subset(size_t min_y, size_t min_x, size_t max_y = 0ull, size_t max_x = 0ull) const;
+
+    Matrix& operator*=(double);               ///< Multiplication by a scalar operator
+    Matrix& operator*=(const Vector&);        ///< Multiplication by a vector operator
+    Matrix& operator*=(const Matrix&);        ///< Multiplication by a matrix operator
+    Matrix operator-() const;                 ///< Unary inverse operator
+    Matrix& operator+=(const Matrix&);        ///< Addition of another matrix
+    Matrix& operator-=(const Matrix&);        ///< Subtraction of another matrix
+    double& operator()(size_t, size_t);       ///< Component access operator
+    double operator()(size_t, size_t) const;  ///< Component retrieval operator
+
+    Vector operator%(const Vector&) const;  ///< Solving operator (from LU decomposition)
+
+    friend Matrix operator*(double, const Matrix&);         ///< Multiplication of a matrix by a scalar
+    friend Matrix operator*(const Matrix&, double);         ///< Multiplication of a matrix by a scalar
+    friend Vector operator*(const Matrix&, const Vector&);  ///< Multiplication of a matrix by a vector
+    friend Matrix operator*(const Matrix&, const Matrix&);  ///< Multiplication of a matrix by another matrix
+    friend Matrix operator+(const Matrix&, const Matrix&);  ///< Addition of two matrices
+    friend Matrix operator-(const Matrix&, const Matrix&);  ///< Subtraction of two matrices
+
+    typedef std::pair<size_t, size_t> Indices;
+    Indices imin() const;  ///< Index (row, column) of the minimum matrix element
+    Indices imax() const;  ///< Index (row, column) of the maximum matrix element
+
+    double min() const;  ///< Minimum matrix element
+    double max() const;  ///< Maximum matrix element
+
+    bool null() const;         ///< Is the matrix uniformly null?
+    bool positive() const;     ///< Is the matrix positive-defined?
+    bool negative() const;     ///< Is the matrix negative-defined?
+    bool nonNegative() const;  ///< Is the matrix non-negative-defined?
+
+    friend std::ostream& operator<<(std::ostream&, const Matrix&);  ///< Printout of matrix components
+
+    Matrix& truncate(double min = 1.e-14);  ///< Truncate (specify minimum non-zero value) for all matrix components
+    Matrix& transpose();                    ///< Transpose the matrix
+    Matrix transposed() const;              ///< Return a transposition of this matrix
+    Matrix& invert();                       ///< Invert the matrix
+    Matrix inverted() const;                ///< Return the inverse of this matrix (LU decomposition)
+    Vector column(size_t) const;            ///< Return whole column of the matrix
+    Vector row(size_t) const;               ///< Return whole row of the matrix
+    Vector diagonal() const;                ///< Return the diagonal components of the matrix
+
+  private:
+    std::unique_ptr<gsl_matrix, void (*)(gsl_matrix*)> gsl_mat_;
+  };
+
+  /// Specialisation of a \f$m\times 1\f$ matrix
+  class Vector : public Matrix {
+  public:
+    /// Object constructor
+    /// \param[in] num_coord vector multiplicity
+    /// \param[in] def default value for all components
+    explicit Vector(size_t num_coord, double def = 0.);
+    /// Build a vector from a {...} list of double precision floats
+    Vector(const std::initializer_list<double>&);
+    /// Build a vector from a GSL vector view (for line/column matrix extraction)
+    Vector(const gsl_vector_view& vec);
+
+    size_t size() const;  ///< Vector multiplicity (number of lines)
+
+    /// Extract a subset of the vector
+    /// \param[in] min first index for the subset
+    /// \param[in] max last index for the subset (last element if not specified)
+    Vector subset(size_t min, size_t max = 0ull) const;
+
+    double& operator()(size_t);         ///< Component access operator
+    double operator()(size_t) const;    ///< Component retrieval operator
+    double dot(const Vector&) const;    ///< Scalar product of two vectors
+    Vector cross(const Vector&) const;  ///< Vector product of two vectors
+
+    friend std::ostream& operator<<(std::ostream&, const Vector&);  ///< Printout of vector components
+  };
+}  // namespace cepgen
+
+#endif

--- a/CepGen/Utils/Algebra.h
+++ b/CepGen/Utils/Algebra.h
@@ -26,6 +26,7 @@
 
 namespace cepgen {
   struct Vector;
+  struct VectorRef;
   /// A \f$n\times m\f$ matrix object
   class Matrix {
   public:
@@ -99,16 +100,34 @@ namespace cepgen {
     friend std::ostream& operator<<(std::ostream&, const Matrix&);  ///< Printout of matrix components
 
     Matrix& truncate(double min = 1.e-14);  ///< Truncate (specify minimum non-zero value) for all matrix components
-    Matrix& transpose();                    ///< Transpose the matrix
-    Matrix transposed() const;              ///< Return a transposition of this matrix
-    Matrix& invert();                       ///< Invert the matrix
-    Matrix inverted() const;                ///< Return the inverse of this matrix (LU decomposition)
-    Vector column(size_t) const;            ///< Return whole column of the matrix
-    Vector row(size_t) const;               ///< Return whole row of the matrix
-    Vector diagonal() const;                ///< Return the diagonal components of the matrix
+
+    Matrix& transpose();        ///< Transpose the matrix
+    Matrix transposed() const;  ///< Return a transposition of this matrix
+    Matrix& invert();           ///< Invert the matrix
+    Matrix inverted() const;    ///< Return the inverse of this matrix (LU decomposition)
+
+    VectorRef column(size_t);     ///< Return whole column of the matrix
+    Vector column(size_t) const;  ///< Return whole column of the matrix
+    VectorRef row(size_t);        ///< Return whole row of the matrix
+    Vector row(size_t) const;     ///< Return whole row of the matrix
+    VectorRef diagonal();         ///< Return the diagonal components of the matrix
+    Vector diagonal() const;      ///< Return the diagonal components of the matrix
 
   private:
     std::unique_ptr<gsl_matrix, void (*)(gsl_matrix*)> gsl_mat_;
+  };
+
+  class VectorRef {
+  public:
+    VectorRef(const gsl_vector_view&);
+
+    VectorRef& operator=(const Vector&);  ///< Assignment operator
+    double& operator()(size_t);           ///< Component access operator
+    double operator()(size_t) const;      ///< Component retrieval operator
+
+  private:
+    gsl_vector_view& view_;
+    friend class Vector;
   };
 
   /// Specialisation of a \f$m\times 1\f$ matrix
@@ -118,10 +137,9 @@ namespace cepgen {
     /// \param[in] num_coord vector multiplicity
     /// \param[in] def default value for all components
     explicit Vector(size_t num_coord, double def = 0.);
-    /// Build a vector from a {...} list of double precision floats
-    Vector(const std::initializer_list<double>&);
-    /// Build a vector from a GSL vector view (for line/column matrix extraction)
-    Vector(const gsl_vector_view& vec);
+    Vector(const std::initializer_list<double>&);  ///< Build a vector from a {...} list of double precision floats
+    Vector(const VectorRef&);                      ///< Build a vector from a GSL vector view
+    Vector(const gsl_vector_const_view&);          ///< Build a vector from a constant GSL vector view
 
     size_t size() const;  ///< Vector multiplicity (number of lines)
 

--- a/test/utils/algebra.cc
+++ b/test/utils/algebra.cc
@@ -59,5 +59,14 @@ int main(int argc, char* argv[]) {
     CG_TEST_EQUAL((D * Dinv - IdD).truncate(), ZeD, "D^{-1}*D");
   }
 
+  {  // lines/columns edit with views
+    auto A = Matrix{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+    const auto new_line = Vector{1, 2, 3};
+    A.row(1) = new_line;
+    CG_LOG << A;
+    //const auto new_A = const_cast<const Matrix&>(A).row(1);
+    CG_TEST_EQUAL(new_A, new_line, "line ref.assignment");
+  }
+
   return 0;
 }

--- a/test/utils/algebra.cc
+++ b/test/utils/algebra.cc
@@ -63,9 +63,7 @@ int main(int argc, char* argv[]) {
     auto A = Matrix{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     const auto new_line = Vector{1, 2, 3};
     A.row(1) = new_line;
-    CG_LOG << A;
-    //const auto new_A = const_cast<const Matrix&>(A).row(1);
-    CG_TEST_EQUAL(new_A, new_line, "line ref.assignment");
+    CG_TEST_EQUAL(A.row(1), new_line, "line ref.assignment");
   }
 
   return 0;

--- a/test/utils/algebra.cc
+++ b/test/utils/algebra.cc
@@ -1,0 +1,63 @@
+#include "CepGen/Utils/Algebra.h"
+#include "CepGen/Utils/ArgumentsParser.h"
+#include "CepGen/Utils/Test.h"
+
+using namespace cepgen;
+
+int main(int argc, char* argv[]) {
+  ArgumentsParser(argc, argv).parse();
+
+  {  // test matrix/vector coordinates retrieval
+    const auto A = Matrix{{1, 2}, {3, 4}};
+    CG_DEBUG("main") << "A =\n" << A << ".";
+    CG_TEST_EQUAL(A(0, 1), 2, "coordinates");
+    const auto diag = Vector{1, 4};
+    CG_TEST_EQUAL(A.diagonal(), diag, "diagonals");
+  }
+
+  const auto B = Matrix{{1, 2, 3}, {4, 5, 6}};
+  CG_DEBUG("main") << "B =\n" << B << ".";
+
+  {  // test transposition
+    auto Bt = B.transposed();
+    CG_TEST_EQUAL(B.numRows(), Bt.numColumns(), "transposed dim.1");
+    CG_TEST_EQUAL(B.numColumns(), Bt.numRows(), "transposed dim.2");
+    const auto &b01 = B(0, 1), &bt10 = Bt(1, 0), &b11 = B(1, 1), &bt11 = Bt(1, 1);
+    CG_TEST_EQUAL(b01, bt10, "transposed coord.1");
+    CG_TEST_EQUAL(b11, bt11, "transposed coord.2");
+  }
+
+  {  // test matrix/vector multiplication
+    const auto v = Vector{7, 8, 9}, res = Vector{50, 122};
+    CG_TEST_EQUAL(B * v, res, "matrix-vector mult.");
+  }
+
+  {  // test matrix/matrix multiplication
+    const auto C = Matrix{{7, 8, 9}, {10, 11, 12}, {13, 14, 15}}, res = Matrix{{66, 72, 78}, {156, 171, 186}};
+    CG_TEST_EQUAL(B * C, res, "matrix-matrix mult.");
+  }
+
+  const auto D = Matrix{// 4x4
+                        {0.18, 0.60, 0.57, 0.96},
+                        {0.41, 0.24, 0.99, 0.58},
+                        {0.14, 0.30, 0.97, 0.66},
+                        {0.51, 0.13, 0.19, 0.85}};
+
+  {  // test linear equations solving
+    const auto w = Vector{1., 2., 3., 4.};
+    const auto res = D * (D % w);
+    // D%w should be close enough to Vector{ -4.05205, -12.6056, 1.66091, 8.69377 }
+    for (size_t i = 0; i < res.numRows(); ++i)
+      CG_TEST_EQUIV(res(i), w(i), "lin.alg.coord." + std::to_string(i));
+  }
+
+  {  // test matrix inversion
+    const auto Dinv = D.inverted();
+    const auto IdD = Matrix::identity(D.numRows());
+    const auto ZeD = Matrix::zero(D.numColumns());
+    CG_TEST_EQUAL((Dinv * D - IdD).truncate(), ZeD, "D*D^{-1}");
+    CG_TEST_EQUAL((D * Dinv - IdD).truncate(), ZeD, "D^{-1}*D");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
New `cepgen::Matrix` and `cepgen::Vector` objects (including a `cepgen::VectorRef` coordinates/accessor reference) wrapping GSL linear algebra structures are introduced to ease the development of new matrix elements.
A basic static test is also added to the suite.