### PR TITLE
Core: event importer modules

### DIFF
--- a/CepGen/EventFilter/EventImporter.h
+++ b/CepGen/EventFilter/EventImporter.h
@@ -1,0 +1,44 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2022  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_EventFilter_EventImporter_h
+#define CepGen_EventFilter_EventImporter_h
+
+#include "CepGen/Modules/NamedModule.h"
+
+namespace cepgen {
+  class Event;
+  /// Base event importer module
+  /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
+  /// \date Dec 2022
+  class EventImporter : public NamedModule<std::string> {
+  public:
+    explicit EventImporter(const ParametersList& params) : NamedModule(params) {}
+
+    static ParametersDescription description() {
+      auto desc = ParametersDescription();
+      desc.setDescription("Unnamed event importer");
+      return desc;
+    }
+
+    /// Output format-custom extraction operator
+    virtual void convert(const void*, Event&) const = 0;
+  };
+}  // namespace cepgen
+
+#endif

--- a/CepGen/EventFilter/EventImporter.h
+++ b/CepGen/EventFilter/EventImporter.h
@@ -45,9 +45,12 @@ namespace cepgen {
       return out;
     }
 
+    /// Read the next event
+    virtual bool next(Event&) const { return false; }
+
   private:
     /// Output format-custom conversion algorithm
-    virtual void convert(const void*, Event&) const = 0;
+    virtual void convert(const void*, Event&) const {}
   };
 }  // namespace cepgen
 

--- a/CepGen/EventFilter/EventImporter.h
+++ b/CepGen/EventFilter/EventImporter.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2022-2023  Laurent Forthomme
+ *  Copyright (C) 2022-2024  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,37 +20,32 @@
 #define CepGen_EventFilter_EventImporter_h
 
 #include "CepGen/Event/Event.h"
-#include "CepGen/Modules/NamedModule.h"
+#include "CepGen/EventFilter/EventHandler.h"
+#include "CepGen/Utils/Value.h"
 
 namespace cepgen {
-  class Event;
   /// Base event importer module
   /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
   /// \date Dec 2022
-  class EventImporter : public NamedModule<std::string> {
+  class EventImporter : public EventHandler {
   public:
-    explicit EventImporter(const ParametersList& params) : NamedModule(params) {}
+    explicit EventImporter(const ParametersList& params) : EventHandler(params) {}
 
     static ParametersDescription description() {
-      auto desc = ParametersDescription();
+      auto desc = EventHandler::description();
       desc.setDescription("Unnamed event importer");
       return desc;
     }
 
-    /// Output format-custom extraction operator
-    template <typename T>
-    Event convert(const T& in) const {
-      Event out;
-      convert((void*)&in, out);
-      return out;
-    }
+    virtual bool operator>>(Event&) const = 0;           ///< Read the next event
+    const Value& crossSection() const { return xsec_; }  ///< Process cross section and uncertainty, in pb
 
-    /// Read the next event
-    virtual bool next(Event&) const { return false; }
+  protected:
+    /// Specify the process cross section and uncertainty, in pb
+    void setCrossSection(const Value& xsec) { xsec_ = xsec; }
 
   private:
-    /// Output format-custom conversion algorithm
-    virtual void convert(const void*, Event&) const {}
+    Value xsec_;
   };
 }  // namespace cepgen
 

--- a/CepGen/EventFilter/EventImporter.h
+++ b/CepGen/EventFilter/EventImporter.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2022  Laurent Forthomme
+ *  Copyright (C) 2022-2023  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #ifndef CepGen_EventFilter_EventImporter_h
 #define CepGen_EventFilter_EventImporter_h
 
+#include "CepGen/Event/Event.h"
 #include "CepGen/Modules/NamedModule.h"
 
 namespace cepgen {
@@ -37,6 +38,15 @@ namespace cepgen {
     }
 
     /// Output format-custom extraction operator
+    template <typename T>
+    Event convert(const T& in) const {
+      Event out;
+      convert((void*)&in, out);
+      return out;
+    }
+
+  private:
+    /// Output format-custom conversion algorithm
     virtual void convert(const void*, Event&) const = 0;
   };
 }  // namespace cepgen

--- a/CepGen/Modules/EventImporterFactory.h
+++ b/CepGen/Modules/EventImporterFactory.h
@@ -1,0 +1,41 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2022  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CepGen_Modules_EventImporterFactory_h
+#define CepGen_Modules_EventImporterFactory_h
+
+#include "CepGen/Modules/ModuleFactory.h"
+
+/** \file */
+
+/// Add a generic export module definition to the factory
+#define REGISTER_EVENT_IMPORTER(name, obj)                                        \
+  namespace cepgen {                                                              \
+    struct BUILDERNM(obj) {                                                       \
+      BUILDERNM(obj)() { EventImporterFactory::get().registerModule<obj>(name); } \
+    };                                                                            \
+    static const BUILDERNM(obj) gIOImporter##obj;                                 \
+  }
+
+namespace cepgen {
+  class EventImporter;
+  /// An event import algorithm factory
+  DEFINE_FACTORY_STR(EventImporterFactory, EventImporter, "Event importers factory");
+}  // namespace cepgen
+
+#endif

--- a/CepGen/Modules/ListModules.cpp
+++ b/CepGen/Modules/ListModules.cpp
@@ -29,6 +29,7 @@
 #include "CepGen/Modules/DerivatorFactory.h"
 #include "CepGen/Modules/DrawerFactory.h"
 #include "CepGen/Modules/EventExporterFactory.h"
+#include "CepGen/Modules/EventImporterFactory.h"
 #include "CepGen/Modules/EventModifierFactory.h"
 #include "CepGen/Modules/FormFactorsFactory.h"
 #include "CepGen/Modules/FunctionalFactory.h"
@@ -77,6 +78,7 @@ namespace cepgen {
       });
       list_modules(AlphaEMFactory::get(), "alpha(EM) evolution algorithms");
       list_modules(AlphaSFactory::get(), "alpha(s) evolution algorithms");
+      list_modules(EventImporterFactory::get(), "Event import modules");
       list_modules(GeneratorWorkerFactory::get(), "Event generation modules");
       list_modules(EventModifierFactory::get(), "Event modification modules");
       list_modules(EventExporterFactory::get(), "Export modules");

--- a/CepGen/Modules/ModuleFactory.cpp
+++ b/CepGen/Modules/ModuleFactory.cpp
@@ -26,6 +26,7 @@
 #include "CepGen/Core/GeneratorWorker.h"
 #include "CepGen/Event/Event.h"
 #include "CepGen/EventFilter/EventExporter.h"
+#include "CepGen/EventFilter/EventImporter.h"
 #include "CepGen/EventFilter/EventModifier.h"
 #include "CepGen/FormFactors/Parameterisation.h"
 #include "CepGen/Integration/AnalyticIntegrator.h"
@@ -137,6 +138,7 @@ namespace cepgen {
   template class ModuleFactory<Coupling, std::string>;
   template class ModuleFactory<utils::Derivator, std::string>;
   template class ModuleFactory<utils::Drawer, std::string>;
+  template class ModuleFactory<EventImporter, std::string>;
   template class ModuleFactory<EventModifier, std::string>;
   template class ModuleFactory<EventExporter, std::string>;
   template class ModuleFactory<formfac::Parameterisation, std::string>;

--- a/CepGenAddOns/HepMC2Wrapper/CMakeLists.txt
+++ b/CepGenAddOns/HepMC2Wrapper/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 cepgen_build(CepGenHepMC2 SOURCES *.cpp
     EXT_LIBS ${HEPMC_LIB}
     EXT_HEADERS ${HEPMC_INCLUDE}
+    TESTS test/*.cc
     INSTALL_COMPONENT hepmc2)
 cpack_add_component(hepmc2
     DISPLAY_NAME "CepGen HepMC wrappers library"

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.cpp
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.cpp
@@ -120,4 +120,10 @@ namespace HepMC {
       set_event_scale(evt.oneWithRole(cepgen::Particle::Role::Intermediate).momentum().mass());
     set_signal_process_vertex(vcm);
   }
+
+  CepGenEvent::operator cepgen::Event() const {
+    cepgen::Event evt;
+    print();
+    return evt;
+  }
 }  // namespace HepMC

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.cpp
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.cpp
@@ -33,8 +33,10 @@
 
 namespace HepMC {
   CepGenEvent::CepGenEvent(const cepgen::Event& evt) : GenEvent(Units::GEV, Units::MM) {
-    set_alphaQCD(evt.metadata.at("alphaS"));
-    set_alphaQED(evt.metadata.at("alphaEM"));
+    if (!evt.metadata.empty()) {
+      set_alphaQCD(evt.metadata.at("alphaS"));
+      set_alphaQED(evt.metadata.at("alphaEM"));
+    }
 
     weights().push_back(1.);  // unweighted events
 
@@ -50,7 +52,7 @@ namespace HepMC {
       auto part = new GenParticle(pmom, part_orig.integerPdgId(), (int)part_orig.status());
       part->set_generated_mass(cepgen::PDG::get().mass(part_orig.pdgId()));
       part->suggest_barcode(idx);
-      assoc_map_[idx].reset(part);
+      assoc_map_[idx] = part;
 
       switch (part_orig.role()) {
         case cepgen::Particle::IncomingBeam1:
@@ -100,7 +102,7 @@ namespace HepMC {
             if (!vprod) {
               vprod = new GenVertex();
               for (const auto& id : ids)
-                vprod->add_particle_in(assoc_map_.at(id).get());
+                vprod->add_particle_in(assoc_map_.at(id));
               add_vertex(vprod);
             }
             vprod->add_particle_out(part);

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h
@@ -36,6 +36,8 @@ namespace HepMC {
   public:
     /// Construct an event interface from a CepGen Event object
     CepGenEvent(const cepgen::Event& ev);
+    /// Extract a CepGen Event object from a HepMC2 GenEvent object
+    operator cepgen::Event() const;
 
   private:
     std::unordered_map<unsigned short, std::shared_ptr<GenParticle> > assoc_map_;

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h
@@ -40,7 +40,7 @@ namespace HepMC {
     operator cepgen::Event() const;
 
   private:
-    std::unordered_map<unsigned short, std::shared_ptr<GenParticle> > assoc_map_;
+    std::unordered_map<unsigned short, GenParticle*> assoc_map_;
   };
 }  // namespace HepMC
 #endif

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2Handler.cpp
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2Handler.cpp
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2023  Laurent Forthomme
+ *  Copyright (C) 2016-2024  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -59,6 +59,10 @@ namespace cepgen {
       event.set_cross_section(*xs_);
       event.set_event_number(event_num_++);
       output_->write_event(&event);
+      CG_DEBUG("HepMC2Handler").log([&event](auto& log) {
+        log << "\n";
+        event.print(log.stream());
+      });
     }
     void setCrossSection(const Value& cross_section) override {
       xs_->set_cross_section((double)cross_section, cross_section.uncertainty());
@@ -66,9 +70,9 @@ namespace cepgen {
 
   private:
     /// Writer object
-    std::unique_ptr<T> output_;
+    const std::unique_ptr<T> output_;
     /// Generator cross section and error
-    std::shared_ptr<GenCrossSection> xs_;
+    const std::shared_ptr<GenCrossSection> xs_;
   };
 }  // namespace cepgen
 

--- a/CepGenAddOns/HepMC2Wrapper/HepMC2Importer.cpp
+++ b/CepGenAddOns/HepMC2Wrapper/HepMC2Importer.cpp
@@ -1,0 +1,59 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2022-2023  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <HepMC/Version.h>
+
+#include <memory>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Event/Event.h"
+#include "CepGen/EventFilter/EventImporter.h"
+#include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h"
+
+using namespace HepMC;
+
+namespace cepgen {
+  /// Handler for the HepMC file output
+  /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
+  /// \date Dec 2022
+  class HepMC2Importer final : public EventImporter {
+  public:
+    /// Class constructor
+    explicit HepMC2Importer(const ParametersList& params) : EventImporter(params) {
+      CG_INFO("HepMC") << "Interfacing module initialised "
+                       << "for HepMC version " << HEPMC_VERSION << ".";
+    }
+
+    static ParametersDescription description() {
+      auto desc = EventImporter::description();
+      desc.setDescription("HepMC2 ASCII file importer module");
+      desc.add<std::string>("filename", "input.hepmc").setDescription("Input filename");
+      return desc;
+    }
+
+    void convert(const void* in, Event& evt) const override {
+      auto* evt_in = static_cast<const HepMC::GenEvent*>(in);
+      evt_in->print();
+      evt = Event(*static_cast<const HepMC::CepGenEvent*>(in));
+    }
+
+  private:
+  };
+}  // namespace cepgen
+REGISTER_EVENT_IMPORTER("hepmc2", HepMC2Importer)

--- a/CepGenAddOns/HepMC2Wrapper/test/extract_event.cc
+++ b/CepGenAddOns/HepMC2Wrapper/test/extract_event.cc
@@ -1,0 +1,34 @@
+#include <HepMC/GenEvent.h>
+
+#include "CepGen/Event/Event.h"
+#include "CepGen/EventFilter/EventExporter.h"
+#include "CepGen/EventFilter/EventImporter.h"
+#include "CepGen/Generator.h"
+#include "CepGen/Modules/EventExporterFactory.h"
+#include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGen/Utils/Test.h"
+
+int main() {
+  cepgen::initialise();
+
+  auto evt = cepgen::Event();
+
+  auto p1 = cepgen::Particle(cepgen::Particle::Role::CentralSystem, 2212, cepgen::Particle::Status::FinalState);
+  p1.momentum().setP(1., 2., 3., 4.);
+  evt.addParticle(p1);
+
+  auto p2 = cepgen::Particle(cepgen::Particle::Role::CentralSystem, 2212, cepgen::Particle::Status::FinalState);
+  p2.momentum().setP(2., 4., 6., 8.);
+  evt.addParticle(p2);
+
+  auto hepmc_out = cepgen::EventExporterFactory::get().build("hepmc");
+  (*hepmc_out) << evt;
+
+  auto hepmc_in = cepgen::EventImporterFactory::get().build("hepmc");
+  HepMC::GenEvent event;
+  event.print();
+  hepmc_in->convert(&event, evt);
+  CG_LOG << evt;
+
+  CG_TEST_SUMMARY;
+}

--- a/CepGenAddOns/HepMC2Wrapper/test/extract_event.cc
+++ b/CepGenAddOns/HepMC2Wrapper/test/extract_event.cc
@@ -1,28 +1,42 @@
-#include <HepMC/GenEvent.h>
-#include <HepMC/IO_GenEvent.h>
-
 #include "CepGen/Event/Event.h"
 #include "CepGen/EventFilter/EventExporter.h"
 #include "CepGen/EventFilter/EventImporter.h"
 #include "CepGen/Generator.h"
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGen/Utils/ArgumentsParser.h"
 #include "CepGen/Utils/Test.h"
 
 using namespace std;
 
-int main() {
+int main(int argc, char* argv[]) {
+  cepgen::ArgumentsParser(argc, argv).parse();
   cepgen::initialise();
 
   auto evt = cepgen::Event();
-
-  auto p1 = cepgen::Particle(cepgen::Particle::Role::CentralSystem, 2212, cepgen::Particle::Status::FinalState);
-  p1.momentum().setP(1., 2., 3., 4.);
-  evt.addParticle(p1);
-
-  auto p2 = cepgen::Particle(cepgen::Particle::Role::CentralSystem, 2212, cepgen::Particle::Status::FinalState);
-  p2.momentum().setP(2., 4., 6., 8.);
-  evt.addParticle(p2);
+  {
+    auto p0 =
+        cepgen::Particle(cepgen::Particle::Role::IncomingBeam1, 2212, cepgen::Particle::Status::PrimordialIncoming);
+    p0.momentum().setP(0.5, 1., 1.5, 2.);
+    evt.addParticle(p0);
+    auto p1 =
+        cepgen::Particle(cepgen::Particle::Role::IncomingBeam2, 2212, cepgen::Particle::Status::PrimordialIncoming);
+    p1.momentum().setP(1., 2., 3., 4.);
+    evt.addParticle(p1);
+    auto p2 = cepgen::Particle(cepgen::Particle::Role::OutgoingBeam1, 2212, cepgen::Particle::Status::FinalState);
+    p2.momentum().setP(2., 4., 6., 8.);
+    evt.addParticle(p2);
+    p2.addMother(p0);
+    auto p3 = cepgen::Particle(cepgen::Particle::Role::OutgoingBeam2, 2212, cepgen::Particle::Status::FinalState);
+    p3.momentum().setP(4., 8., 12., 16.);
+    evt.addParticle(p3);
+    p3.addMother(p1);
+    auto p4 = cepgen::Particle(cepgen::Particle::Role::CentralSystem, 12, cepgen::Particle::Status::FinalState);
+    p4.momentum().setP(8., 16., 24., 32.);
+    evt.addParticle(p4);
+    p4.addMother(p0);
+    p4.addMother(p1);
+  }
 
   auto temp_file = "/tmp/test_hepmc.out";
   {
@@ -31,12 +45,10 @@ int main() {
     (*hepmc_out) << evt;
   }
   {
-    auto hepmc_in = cepgen::EventImporterFactory::get().build("hepmc2");
-    HepMC::IO_GenEvent reader(temp_file, std::ios::in);
-    HepMC::GenEvent event;
-    CG_TEST_EQUAL(reader.fill_next_event(&event), true, "Event re-import [HepMC2]");
-
-    auto evt_in = hepmc_in->convert(event);
+    auto hepmc_in = cepgen::EventImporterFactory::get().build(
+        "hepmc2", cepgen::ParametersList().set<string>("filename", temp_file));
+    cepgen::Event evt_in;
+    CG_TEST_EQUAL(((*hepmc_in) >> evt_in), true, "Event re-import [HepMC2]");
     CG_TEST_EQUAL(evt_in.size(), evt.size(), "Event re-import size");
     for (const auto& part : evt_in.particles()) {
       //CG_TEST_EQUAL(part.pdgId(), evt[part.id()].pdgId(), "Event re-import");

--- a/CepGenAddOns/HepMC2Wrapper/test/extract_event.cc
+++ b/CepGenAddOns/HepMC2Wrapper/test/extract_event.cc
@@ -1,4 +1,5 @@
 #include <HepMC/GenEvent.h>
+#include <HepMC/IO_GenEvent.h>
 
 #include "CepGen/Event/Event.h"
 #include "CepGen/EventFilter/EventExporter.h"
@@ -7,6 +8,8 @@
 #include "CepGen/Modules/EventExporterFactory.h"
 #include "CepGen/Modules/EventImporterFactory.h"
 #include "CepGen/Utils/Test.h"
+
+using namespace std;
 
 int main() {
   cepgen::initialise();
@@ -21,14 +24,24 @@ int main() {
   p2.momentum().setP(2., 4., 6., 8.);
   evt.addParticle(p2);
 
-  auto hepmc_out = cepgen::EventExporterFactory::get().build("hepmc");
-  (*hepmc_out) << evt;
+  auto temp_file = "/tmp/test_hepmc.out";
+  {
+    auto hepmc_out = cepgen::EventExporterFactory::get().build(
+        "hepmc2", cepgen::ParametersList().set<string>("filename", temp_file));
+    (*hepmc_out) << evt;
+  }
+  {
+    auto hepmc_in = cepgen::EventImporterFactory::get().build("hepmc2");
+    HepMC::IO_GenEvent reader(temp_file, std::ios::in);
+    HepMC::GenEvent event;
+    CG_TEST_EQUAL(reader.fill_next_event(&event), true, "Event re-import [HepMC2]");
 
-  auto hepmc_in = cepgen::EventImporterFactory::get().build("hepmc");
-  HepMC::GenEvent event;
-  event.print();
-  hepmc_in->convert(&event, evt);
-  CG_LOG << evt;
+    auto evt_in = hepmc_in->convert(event);
+    CG_TEST_EQUAL(evt_in.size(), evt.size(), "Event re-import size");
+    for (const auto& part : evt_in.particles()) {
+      //CG_TEST_EQUAL(part.pdgId(), evt[part.id()].pdgId(), "Event re-import");
+    }
+  }
 
   CG_TEST_SUMMARY;
 }

--- a/CepGenAddOns/HepMC3Wrapper/LHEFHepMCImporter.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/LHEFHepMCImporter.cpp
@@ -1,0 +1,90 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <HepMC3/LHEF.h>
+#include <HepMC3/Version.h>
+
+#include <memory>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Event/Event.h"
+#include "CepGen/EventFilter/EventImporter.h"
+#include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h"
+
+namespace cepgen {
+  /// HepMC3 handler for the LHEF file import
+  /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
+  /// \date Feb 2024
+  class LHEFHepMCImporter final : public EventImporter {
+  public:
+    /// Class constructor
+    explicit LHEFHepMCImporter(const ParametersList& params) : EventImporter(params) {
+      if (const auto filename = steer<std::string>("filename"); !filename.empty()) {
+        try {
+          reader_.reset(new LHEF::Reader(filename));
+        } catch (std::runtime_error& err) {
+          throw CG_FATAL("LHEFHepMCImporter") << "Failed to load the LHEF file. Error:\n" << err.what();
+        }
+        CG_INFO("LHEFHepMCImporter") << "Interfacing module initialised "
+                                     << "for HepMC version " << HEPMC3_VERSION << " and LHEF file '" << filename
+                                     << "' with version " << reader_->version << ".";
+      } else
+        throw CG_FATAL("LHEFHepMCImporter") << "Failed to retrieve the file name from module builder attributes.";
+    }
+
+    static ParametersDescription description() {
+      auto desc = EventImporter::description();
+      desc.setDescription("HepMC3 LHEF file importer module");
+      desc.add<std::string>("filename", "input.lhef").setDescription("Input filename");
+      return desc;
+    }
+
+    bool next(Event& evt) const override {
+      if (!reader_->readEvent())
+        return false;
+      evt.clear();
+      const auto& hepeup = reader_->hepeup;
+      CG_DEBUG("LHEFHepMCImporter:next").log([&hepeup](auto& log) { hepeup.print(log.stream()); });
+      for (int i = 0; i < hepeup.NUP; ++i) {
+        Particle part;
+        part.setRole(Particle::Role::CentralSystem);
+        part.setPdgId((long)hepeup.IDUP.at(i));
+        const auto& hepeup_mom = hepeup.PUP.at(i);
+        part.setMomentum(Momentum::fromPxPyPzE(hepeup_mom.at(0), hepeup_mom.at(1), hepeup_mom.at(2), hepeup_mom.at(3)),
+                         false);
+        part.setStatus(hepeup.ISTUP.at(i) < 0 ? Particle::Status::Propagator : Particle::Status::FinalState);
+        if (hepeup.ISTUP.at(i) == -1) {
+          part.setStatus(Particle::Status::PrimordialIncoming);
+          part.setRole(part.momentum().pz() > 0 ? Particle::Role::IncomingBeam1 : Particle::Role::IncomingBeam2);
+        }
+        const auto& moth = hepeup.MOTHUP.at(i);
+        if (moth.first > 0)
+          part.addMother(evt[moth.first - 1]);
+        if (moth.second > 0)
+          part.addMother(evt[moth.second - 1]);
+        evt.addParticle(part);
+      }
+      return true;
+    }
+
+  private:
+    std::unique_ptr<LHEF::Reader> reader_;
+  };
+}  // namespace cepgen
+REGISTER_EVENT_IMPORTER("lhef", LHEFHepMCImporter)

--- a/CepGenAddOns/HepMC3Wrapper/LHEFHepMCImporter.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/LHEFHepMCImporter.cpp
@@ -55,7 +55,7 @@ namespace cepgen {
       return desc;
     }
 
-    bool next(Event& evt) const override {
+    bool operator>>(Event& evt) const override {
       if (!reader_->readEvent())
         return false;
       evt.clear();
@@ -84,6 +84,12 @@ namespace cepgen {
     }
 
   private:
+    void initialise() override {
+      const auto& heprup = reader_->heprup;
+      CG_DEBUG("LHEFHepMCImporter").log([&heprup](auto& log) { heprup.print(log.stream()); });
+      setCrossSection(Value{heprup.XSECUP[0], heprup.XERRUP[0]});
+    }
+
     std::unique_ptr<LHEF::Reader> reader_;
   };
 }  // namespace cepgen

--- a/CepGenAddOns/ROOTWrapper/ROOTTreeImporter.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTTreeImporter.cpp
@@ -1,0 +1,62 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <TFile.h>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Core/RunParameters.h"
+#include "CepGen/Event/Event.h"
+#include "CepGen/EventFilter/EventImporter.h"
+#include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGen/Utils/Value.h"
+#include "CepGenAddOns/ROOTWrapper/ROOTTreeInfo.h"
+
+namespace cepgen {
+  /// ROOT handler for an event tree import
+  /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
+  /// \date Feb 2024
+  class ROOTTreeImporter : public EventImporter {
+  public:
+    /// Class constructor
+    explicit ROOTTreeImporter(const ParametersList& params)
+        : EventImporter(params), file_(TFile::Open(steer<std::string>("filename").data())) {
+      if (!file_)
+        throw CG_FATAL("ROOTTreeImporter")
+            << "Failed to load the ROOT file '" << steer<std::string>("filename") << "'.";
+      run_tree_.attach(file_.get());
+      evt_tree_.attach(file_.get());
+    }
+
+    static ParametersDescription description() {
+      auto desc = EventImporter::description();
+      desc.setDescription("ROOT TTree importer module");
+      desc.add<std::string>("filename", "output.root").setDescription("Input filename");
+      return desc;
+    }
+
+    bool operator>>(Event& evt) const override { return evt_tree_.next(evt); }
+
+  private:
+    void initialise() override { setCrossSection(Value{run_tree_.xsect, run_tree_.errxsect}); }
+
+    const std::unique_ptr<TFile> file_;
+    ROOT::CepGenRun run_tree_;
+    mutable ROOT::CepGenEvent evt_tree_;
+  };
+}  // namespace cepgen
+REGISTER_EVENT_IMPORTER("root_tree", ROOTTreeImporter);

--- a/src/utils/cepgenDescribeModules.cc
+++ b/src/utils/cepgenDescribeModules.cc
@@ -28,6 +28,7 @@
 #include "CepGen/Modules/DerivatorFactory.h"
 #include "CepGen/Modules/DrawerFactory.h"
 #include "CepGen/Modules/EventExporterFactory.h"
+#include "CepGen/Modules/EventImporterFactory.h"
 #include "CepGen/Modules/EventModifierFactory.h"
 #include "CepGen/Modules/FormFactorsFactory.h"
 #include "CepGen/Modules/FunctionalFactory.h"
@@ -126,6 +127,7 @@ int main(int argc, char* argv[]) {
     LOOP_FACTORY("Cards steering", cepgen::CardsHandlerFactory);
     // event management
     LOOP_FACTORY("Process", cepgen::ProcessFactory);
+    LOOP_FACTORY("Event import", cepgen::EventImporterFactory);
     LOOP_FACTORY("Event generation", cepgen::GeneratorWorkerFactory);
     LOOP_FACTORY("Event modification", cepgen::EventModifierFactory);
     LOOP_FACTORY("Event export", cepgen::EventExporterFactory);

--- a/src/utils/cepgenEventConverter.cc
+++ b/src/utils/cepgenEventConverter.cc
@@ -1,0 +1,61 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Core/RunParameters.h"
+#include "CepGen/EventFilter/EventExporter.h"
+#include "CepGen/EventFilter/EventImporter.h"
+#include "CepGen/Generator.h"
+#include "CepGen/Modules/EventExporterFactory.h"
+#include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGen/Utils/ArgumentsParser.h"
+#include "CepGen/Utils/Filesystem.h"
+#include "CepGen/Utils/String.h"
+
+using namespace std;
+
+int main(int argc, char* argv[]) {
+  string input_file, output_file;
+
+  cepgen::ArgumentsParser parser(argc, argv);
+  parser.addArgument("input,i", "input event file", &input_file)
+      .addArgument("output,o", "output event file", &output_file)
+      .parse();
+
+  cepgen::initialise();
+
+  auto params = cepgen::RunParameters{};
+
+  auto reader = cepgen::EventImporterFactory::get().build(input_file);
+  reader->initialise(params);
+  auto writer = cepgen::EventExporterFactory::get().build(output_file);
+  writer->initialise(params);
+
+  writer->setCrossSection(reader->crossSection());
+
+  cepgen::Event buf;
+  size_t num_events_converted = 0;
+  while ((*reader) >> buf) {
+    (*writer) << buf;
+    ++num_events_converted;
+  }
+
+  CG_LOG << "Successfully converted " << cepgen::utils::s("event", num_events_converted, true) << ".";
+
+  return 0;
+}


### PR DESCRIPTION
A new base event importer module object is introduced, along with the implementation of major importers (LHEF, HepMC, and ROOT) with more to come.