### PR TITLE
Utils: MCD parser empty info detection

### DIFF
--- a/CepGen/Physics/MCDFileParser.cpp
+++ b/CepGen/Physics/MCDFileParser.cpp
@@ -49,13 +49,23 @@ namespace pdg {
       }
       {                                      // mass + error(s)
         double mass_err_low, mass_err_high;  // unused
-        std::istringstream oss(line.substr(MASS_BEG, MASS_END));
-        oss >> mass >> mass_err_low >> mass_err_high;
+        const auto mass_substr = cepgen::utils::trim(line.substr(MASS_BEG, MASS_END));
+        if (mass_substr.empty())
+          mass = mass_err_low = mass_err_high = 0.;
+        else {
+          std::istringstream oss(mass_substr);
+          oss >> mass >> mass_err_low >> mass_err_high;
+        }
       }
       {                                        // width + error(s)
         double width_err_low, width_err_high;  // unused
-        std::istringstream oss(line.substr(WIDTH_BEG, WIDTH_END));
-        oss >> width >> width_err_low >> width_err_high;
+        const auto width_substr = cepgen::utils::trim(line.substr(WIDTH_BEG, WIDTH_END));
+        if (width_substr.empty())
+          width = width_err_low = width_err_high = 0.;
+        else {
+          std::istringstream oss(width_substr);
+          oss >> width >> width_err_low >> width_err_high;
+        }
       }
       {  // name + charge
         std::istringstream oss(line.substr(AUX_BEG));

--- a/test/physics/mcd_parser.cc
+++ b/test/physics/mcd_parser.cc
@@ -35,10 +35,14 @@ int main(int argc, char* argv[]) {
 
   pdg::MCDFileParser::parse(path);
   cepgen::PDG::get().dump();
+  CG_TEST_SET_PRECISION(1.e-6);
 
-  CG_TEST_EQUAL(cepgen::PDG::get().mass(cepgen::PDG::diffractiveProton), 0., "diffractive proton bare mass");
-  CG_TEST_EQUAL(cepgen::PDG::get().mass(6), 172.5, "top mass");
-  CG_TEST_EQUAL(cepgen::PDG::get().width(13), 2.9959836e-19, "muon width");
+  CG_TEST_EQUIV(cepgen::PDG::get().mass(cepgen::PDG::diffractiveProton), 0., "diffractive proton bare mass");
+  CG_TEST_EQUIV(cepgen::PDG::get().mass(6), 172.5, "top mass");
+  CG_TEST_EQUIV(cepgen::PDG::get().width(13), 2.9959836e-19, "muon width");
+  CG_TEST_EQUIV(cepgen::PDG::get().mass(12), 0., "electron neutrino mass");
+  CG_TEST_EQUIV(cepgen::PDG::get().mass(14), 0., "muon neutrino mass");
+  CG_TEST_EQUIV(cepgen::PDG::get().mass(16), 0., "tau neutrino mass");
 
   CG_TEST_SUMMARY;
 }


### PR DESCRIPTION
This PR fixes a problem observed when particle masses and/or width are not specified in MCD input.

Fixes #47.