### PR TITLE
Fix of HepMC3 output PDG id and factorised processes central particles status codes

### DIFF
--- a/CepGen/EventFilter/EventImporter.h
+++ b/CepGen/EventFilter/EventImporter.h
@@ -37,7 +37,7 @@ namespace cepgen {
       return desc;
     }
 
-    virtual bool operator>>(Event&) const = 0;           ///< Read the next event
+    virtual bool operator>>(Event&) = 0;                 ///< Read the next event
     const Value& crossSection() const { return xsec_; }  ///< Process cross section and uncertainty, in pb
 
   protected:

--- a/CepGen/Process/Process2to4.cpp
+++ b/CepGen/Process/Process2to4.cpp
@@ -138,8 +138,8 @@ namespace cepgen {
 
     void Process2to4::fillCentralParticlesKinematics() {
       const short sign = rnd_gen_->uniformInt(0, 1) == 1 ? 1 : -1;  // randomise the charge of outgoing system
-      event()[Particle::CentralSystem][0].get().setChargeSign(+sign).setStatus(Particle::Status::Undecayed);
-      event()[Particle::CentralSystem][1].get().setChargeSign(-sign).setStatus(Particle::Status::Undecayed);
+      event()[Particle::CentralSystem][0].get().setChargeSign(+sign).setStatus(Particle::Status::FinalState);
+      event()[Particle::CentralSystem][1].get().setChargeSign(-sign).setStatus(Particle::Status::FinalState);
     }
 
     //----- utilities

--- a/CepGenAddOns/Common/EventUtils.h
+++ b/CepGenAddOns/Common/EventUtils.h
@@ -63,9 +63,9 @@ namespace cepgen {
 
       // generate dilepton system kinematics
       auto oc = evt[cepgen::Particle::CentralSystem];
-      oc[0].get().setPdgId(cepgen::PDG::muon);
+      oc[0].get().setPdgId(cepgen::PDG::muon, -1);
       oc[0].get().setMomentum(cepgen::Momentum::fromPxPyPzE(2.193109e1, -6.725967e1, -4.248568e1, 8.252200e1), false);
-      oc[1].get().setPdgId(cepgen::PDG::muon);
+      oc[1].get().setPdgId(cepgen::PDG::muon, +1);
       oc[1].get().setMomentum(cepgen::Momentum::fromPxPyPzE(-1.402852e1, 5.906575e1, 6.430959e1, 8.843809e1), false);
       return evt;
     }

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.cpp
@@ -30,6 +30,7 @@
 #include "CepGen/Event/Event.h"
 #include "CepGen/Physics/Constants.h"
 #include "CepGen/Physics/PDG.h"
+#include "CepGen/Utils/String.h"
 #include "CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h"
 
 namespace HepMC3 {
@@ -105,7 +106,7 @@ namespace HepMC3 {
             }
             vprod->add_particle_out(part);
           } else
-            throw CG_FATAL("HepMCHandler:fillEvent") << "Other particle requested! Not yet implemented!";
+            throw CG_FATAL("HepMC3:fillEvent") << "Other particle requested! Not yet implemented!";
         } break;
       }
       idx++;
@@ -117,6 +118,81 @@ namespace HepMC3 {
 
   std::ostream& operator<<(std::ostream& os, const FourVector& vec) {
     return os << "(" << vec.x() << ", " << vec.y() << ", " << vec.z() << "; " << vec.t() << ")";
+  }
+
+  CepGenEvent::operator cepgen::Event() const {
+    cepgen::Event evt;
+    auto convert_particle = [](const GenParticle& part,
+                               const cepgen::Particle::Role& role =
+                                   cepgen::Particle::Role::UnknownRole) -> cepgen::Particle {
+      auto convert_momentum = [](const FourVector& mom) -> cepgen::Momentum {
+        return cepgen::Momentum::fromPxPyPzE(mom.px(), mom.py(), mom.pz(), mom.e());
+      };
+      auto cg_part = cepgen::Particle(role, 0, (cepgen::Particle::Status)part.status());
+      cg_part.setPdgId((long)part.pdg_id());
+      cg_part.setMomentum(convert_momentum(part.momentum()));
+      return cg_part;
+    };
+
+    auto ip1 = beams().at(0), ip2 = beams().at(1);
+    std::unordered_map<size_t, size_t> h_to_cg;
+    std::vector<int> beam_vtx_ids;
+    for (const auto& vtx : vertices()) {
+      if (vtx->particles_in().size() == 1) {
+        auto role1 = cepgen::Particle::Role::UnknownRole, role2 = role1, role3 = role1;
+        auto status1 = cepgen::Particle::Status::PrimordialIncoming, status2 = cepgen::Particle::Status::Incoming,
+             status3 = cepgen::Particle::Status::Unfragmented;
+        size_t id_beam_in = 0;
+        if (auto& part = vtx->particles_in().at(0); part) {
+          if (part->id() == ip1->id()) {
+            role1 = cepgen::Particle::IncomingBeam1;
+            role2 = cepgen::Particle::Parton1;
+            role3 = cepgen::Particle::OutgoingBeam1;
+          } else if (part->id() == ip2->id()) {
+            role1 = cepgen::Particle::IncomingBeam2;
+            role2 = cepgen::Particle::Parton2;
+            role3 = cepgen::Particle::OutgoingBeam2;
+          }
+          auto cg_part = convert_particle(*part, role1);
+          cg_part.setStatus(status1);
+          evt.addParticle(cg_part);
+          h_to_cg[part->id()] = cg_part.id();
+          id_beam_in = cg_part.id();
+        }
+        if (vtx->particles_out_size() == 2) {  //FIXME handle cases with multiple partons?
+          size_t num_op = 0;
+          for (auto op : vtx->particles_out()) {
+            auto cg_part = convert_particle(*op, num_op == 0 ? role2 : role3);
+            cg_part.setStatus(num_op == 0 ? status2 : status3);
+            cg_part.addMother(evt[id_beam_in]);
+            evt.addParticle(cg_part);
+            h_to_cg[op->id()] = cg_part.id();
+            ++num_op;
+          }
+        }
+        beam_vtx_ids.emplace_back(vtx->id());
+      }
+    }
+
+    auto cg_interm = cepgen::Particle(cepgen::Particle::Role::Intermediate, 0, cepgen::Particle::Status::Propagator);
+    auto &part1 = evt.oneWithRole(cepgen::Particle::Role::Parton1),
+         &part2 = evt.oneWithRole(cepgen::Particle::Role::Parton2);
+    cg_interm.setMomentum(part1.momentum() + part2.momentum(), true);
+    cg_interm.addMother(part1);
+    cg_interm.addMother(part2);
+    evt.addParticle(cg_interm);
+
+    for (const auto& vtx : vertices()) {
+      if (cepgen::utils::contains(beam_vtx_ids, vtx->id()))
+        continue;
+      for (auto op : vtx->particles_out()) {
+        auto cg_part = convert_particle(*op, cepgen::Particle::Role::CentralSystem);
+        cg_part.addMother(evt.oneWithRole(cepgen::Particle::Role::Intermediate));
+        evt.addParticle(cg_part);
+        h_to_cg[op->id()] = cg_part.id();
+      }
+    }
+    return evt;
   }
 
   void CepGenEvent::merge(cepgen::Event& evt) const {

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.cpp
@@ -49,7 +49,7 @@ namespace HepMC3 {
     for (const auto& part_orig : evt.particles()) {
       const auto& mom_orig = part_orig.momentum();
       FourVector pmom(mom_orig.px(), mom_orig.py(), mom_orig.pz(), mom_orig.energy());
-      auto part = make_shared<GenParticle>(pmom, part_orig.pdgId(), (int)part_orig.status());
+      auto part = make_shared<GenParticle>(pmom, part_orig.integerPdgId(), (int)part_orig.status());
       part->set_generated_mass(cepgen::PDG::get().mass(part_orig.pdgId()));
       assoc_map_[idx] = part;
 

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h
@@ -36,7 +36,8 @@ namespace HepMC3 {
   public:
     /// Construct an event interface from a CepGen Event object
     CepGenEvent(const cepgen::Event&);
-
+    /// Extract a CepGen Event object from a HepMC3 GenEvent object
+    operator cepgen::Event() const;
     /// Write the event content in the standard stream
     void dump() const;
 

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3Importer.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3Importer.cpp
@@ -1,0 +1,70 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/Print.h>
+#include <HepMC3/ReaderAscii.h>
+#include <HepMC3/Version.h>
+
+#include <memory>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/EventFilter/EventImporter.h"
+#include "CepGen/Modules/EventImporterFactory.h"
+#include "CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h"
+
+namespace cepgen {
+  /// Handler for the HepMC file output
+  /// \author Laurent Forthomme <laurent.forthomme@cern.ch>
+  /// \date Feb 2024
+  template <typename T>
+  class HepMC3Importer final : public EventImporter {
+  public:
+    /// Class constructor
+    explicit HepMC3Importer(const ParametersList& params)
+        : EventImporter(params), reader_(new T(steer<std::string>("filename"))) {
+      if (!reader_)
+        throw CG_FATAL("HepMC3Importer") << "Failed to initialise HepMC reader.";
+      CG_INFO("HepMC3Importer") << "Interfacing module initialised "
+                                << "for HepMC version " << HEPMC3_VERSION << " and HepMC ASCII file '"
+                                << steer<std::string>("filename") << "'.";
+    }
+
+    bool operator>>(Event& evt) const override {
+      HepMC3::GenEvent event;
+      if (!reader_->read_event(event))
+        return false;
+      CG_DEBUG("HepMC3Importer").log([&event](auto& log) { HepMC3::Print::content(log.stream(), event); });
+      evt = Event(static_cast<const HepMC3::CepGenEvent&>(event));
+      return true;
+    }
+
+    static ParametersDescription description() {
+      auto desc = EventImporter::description();
+      desc.setDescription("HepMC3 ASCII file importer module");
+      desc.add<std::string>("filename", "input.hepmc").setDescription("Input filename");
+      return desc;
+    }
+
+  private:
+    void initialise() override {}
+    const std::unique_ptr<T> reader_;
+  };
+}  // namespace cepgen
+typedef cepgen::HepMC3Importer<HepMC3::ReaderAscii> HepMC3ImporterASCII;
+REGISTER_EVENT_IMPORTER("hepmc", HepMC3ImporterASCII)

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3Importer.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3Importer.cpp
@@ -76,7 +76,7 @@ namespace cepgen {
 typedef cepgen::HepMC3Importer<HepMC3::ReaderAscii> HepMC3ImporterASCII;
 typedef cepgen::HepMC3Importer<HepMC3::ReaderHEPEVT> HepMC3ImporterHEPEVT;
 REGISTER_EVENT_IMPORTER("hepmc", HepMC3ImporterASCII);
-REGISTER_EVENT_IMPORTER("hepevt", HepMC3ImporterHEPEVT);
+//REGISTER_EVENT_IMPORTER("hepevt", HepMC3ImporterHEPEVT); // HEPEVT input is still very shaky, disabling it by default
 #if HEPMC3_VERSION_CODE >= 3001000
 #include <HepMC3/ReaderAsciiHepMC2.h>
 typedef cepgen::HepMC3Importer<HepMC3::ReaderAsciiHepMC2> HepMC3ImporterHepMC2;

--- a/CepGenAddOns/HepMC3Wrapper/HepMC3Importer.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/HepMC3Importer.cpp
@@ -19,6 +19,7 @@
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/Print.h>
 #include <HepMC3/ReaderAscii.h>
+#include <HepMC3/ReaderHEPEVT.h>
 #include <HepMC3/Version.h>
 
 #include <memory>
@@ -67,4 +68,6 @@ namespace cepgen {
   };
 }  // namespace cepgen
 typedef cepgen::HepMC3Importer<HepMC3::ReaderAscii> HepMC3ImporterASCII;
-REGISTER_EVENT_IMPORTER("hepmc", HepMC3ImporterASCII)
+typedef cepgen::HepMC3Importer<HepMC3::ReaderHEPEVT> HepMC3ImporterHEPEVT;
+REGISTER_EVENT_IMPORTER("hepmc", HepMC3ImporterASCII);
+REGISTER_EVENT_IMPORTER("hepevt", HepMC3ImporterHEPEVT);

--- a/CepGenAddOns/HepMC3Wrapper/LHEFHepMCHandler.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/LHEFHepMCHandler.cpp
@@ -47,6 +47,10 @@ namespace cepgen {
     }
 
     bool operator<<(const Event& cg_ev) override {
+      if (!header_initialised_) {
+        lhe_output_->init();  // ensure everything is properly parsed
+        header_initialised_ = true;
+      }
       auto& hepeup = lhe_output_->hepeup;
       hepeup.heprup = &lhe_output_->heprup;
       hepeup.XWGTUP = 1.;
@@ -95,11 +99,11 @@ namespace cepgen {
       lhe_output_->heprup.LPRUP[0] = 1;
       lhe_output_->heprup.XSECUP[0] = 0.;  // placeholders
       lhe_output_->heprup.XERRUP[0] = 0.;
-      lhe_output_->init();  // ensure everything is properly parsed
     }
 
     const std::unique_ptr<LHEF::Writer> lhe_output_;
     const bool compress_;
+    bool header_initialised_{false};
   };
 }  // namespace cepgen
 REGISTER_EXPORTER("lhef_hepmc", LHEFHepMCHandler);

--- a/CepGenAddOns/HepMC3Wrapper/LHEFHepMCImporter.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/LHEFHepMCImporter.cpp
@@ -56,7 +56,7 @@ namespace cepgen {
       return desc;
     }
 
-    bool operator>>(Event& evt) const override {
+    bool operator>>(Event& evt) override {
       if (!reader_->readEvent())
         return false;
       evt.clear();
@@ -101,10 +101,8 @@ namespace cepgen {
           else
             part.setRole(Particle::Role::Parton2);
         }
-        CG_LOG << part;
         evt.addParticle(part);
       }
-      CG_LOG << evt;
       return true;
     }
 

--- a/CepGenAddOns/ROOTWrapper/ROOTTreeImporter.cpp
+++ b/CepGenAddOns/ROOTWrapper/ROOTTreeImporter.cpp
@@ -49,7 +49,7 @@ namespace cepgen {
       return desc;
     }
 
-    bool operator>>(Event& evt) const override { return evt_tree_.next(evt); }
+    bool operator>>(Event& evt) override { return evt_tree_.next(evt); }
 
   private:
     void initialise() override { setCrossSection(Value{run_tree_.xsect, run_tree_.errxsect}); }

--- a/test/utils/write_and_read_event.cc
+++ b/test/utils/write_and_read_event.cc
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
     if (cepgen::utils::contains(readers, mod))
       common.emplace_back(mod);
 
-  cepgen::ArgumentsParser(argc, argv).parse();
+  cepgen::ArgumentsParser(argc, argv).addOptionalArgument("modules,m", "modules to test", &common, common).parse();
   CG_INFO("main") << "Will test with the following writer/reader pairs: " << common << ".";
 
   const auto evt_base = cepgen::utils::generateLPAIREvent();

--- a/test/utils/write_and_read_event.cc
+++ b/test/utils/write_and_read_event.cc
@@ -42,6 +42,7 @@ int main(int argc, char* argv[]) {
   CG_INFO("main") << "Will test with the following writer/reader pairs: " << common << ".";
 
   const auto evt_base = cepgen::utils::generateLPAIREvent();
+  const auto xsect = cepgen::Value{42.4242, 0.4242};
   for (const auto& mod : common) {
     string temp_file = "output.txt";  // default value
 
@@ -49,6 +50,7 @@ int main(int argc, char* argv[]) {
       auto writer = cepgen::EventExporterFactory::get().build(mod);
       temp_file = writer->parameters().get<string>("filename");
       writer->initialise(gen.runParameters());
+      writer->setCrossSection(xsect);
       const auto wrote = ((*writer) << evt_base);
       CG_TEST(wrote, "event export: " + mod);
       if (!wrote)
@@ -61,6 +63,8 @@ int main(int argc, char* argv[]) {
       cepgen::Event evt_in;
       CG_TEST_EQUAL(((*reader) >> evt_in), true, "event re-import: " + mod);
       CG_TEST_EQUAL(evt_in.size(), evt_base.size(), "event re-import size: " + mod);
+      if (mod != "hepevt")  // we know this does not support storing x-section
+        CG_TEST_EQUAL(reader->crossSection(), xsect, "stored cross-section: " + mod);
       for (const auto& role : {cepgen::Particle::Role::IncomingBeam1,
                                cepgen::Particle::Role::IncomingBeam2,
                                cepgen::Particle::Role::OutgoingBeam1,

--- a/test/utils/write_and_read_event.cc
+++ b/test/utils/write_and_read_event.cc
@@ -43,6 +43,9 @@ int main(int argc, char* argv[]) {
 
   const auto evt_base = cepgen::utils::generateLPAIREvent();
   const auto xsect = cepgen::Value{42.4242, 0.4242};
+
+  CG_DEBUG("main") << "Input event to be tested:\n" << evt_base;
+
   for (const auto& mod : common) {
     string temp_file = "output.txt";  // default value
 
@@ -63,8 +66,7 @@ int main(int argc, char* argv[]) {
       cepgen::Event evt_in;
       CG_TEST_EQUAL(((*reader) >> evt_in), true, "event re-import: " + mod);
       CG_TEST_EQUAL(evt_in.size(), evt_base.size(), "event re-import size: " + mod);
-      if (mod != "hepevt")  // we know this does not support storing x-section
-        CG_TEST_EQUAL(reader->crossSection(), xsect, "stored cross-section: " + mod);
+      CG_TEST_EQUAL(reader->crossSection(), xsect, "stored cross-section: " + mod);
       for (const auto& role : {cepgen::Particle::Role::IncomingBeam1,
                                cepgen::Particle::Role::IncomingBeam2,
                                cepgen::Particle::Role::OutgoingBeam1,
@@ -73,8 +75,8 @@ int main(int argc, char* argv[]) {
                                cepgen::Particle::Role::Parton2}) {
         ostringstream os_role;
         os_role << role;
-        CG_TEST_EQUAL(evt_in.oneWithRole(role).pdgId(),
-                      evt_base.oneWithRole(role).pdgId(),
+        CG_TEST_EQUAL(evt_in.oneWithRole(role).integerPdgId(),
+                      evt_base.oneWithRole(role).integerPdgId(),
                       "PDG of " + os_role.str() + ": " + mod);
         CG_TEST_EQUIV(evt_in.oneWithRole(role).momentum().px(),
                       evt_base.oneWithRole(role).momentum().px(),


### PR DESCRIPTION
In an attempt to fix #52, the HepMC3 interface is sanitised and an HepMC3 event importer is introduced, with corresponding tests.
Additionally, the cross section can now be retrieved from HepMC2/3 formats.

To fix #53, 2-to-4 factorised processes are now emitting particles with status 1 by default, unless specified differently in the process definition and/or hadronisation algorithms event pre-treatment.