### PR TITLE
Fix of LPAIR z-dependent distributions in SD mode

### DIFF
--- a/CepGen/Core/Generator.cpp
+++ b/CepGen/Core/Generator.cpp
@@ -65,6 +65,7 @@ namespace cepgen {
     worker_->setIntegrator(integrator_.get());
     xsect_ = Value{-1., -1.};
     parameters_->prepareRun();
+    initialised_ = false;
   }
 
   const RunParameters& Generator::runParameters() const {
@@ -166,8 +167,6 @@ namespace cepgen {
   }
 
   void Generator::initialise() {
-    if (initialised_)
-      return;
     if (!parameters_)
       throw CG_FATAL("Generator:generate") << "No steering parameters specified!";
 

--- a/CepGen/Generator.h
+++ b/CepGen/Generator.h
@@ -95,12 +95,8 @@ namespace cepgen {
     RunParameters& runParameters();              ///< Run parameters block
     void setRunParameters(RunParameters* ip);    ///< Feed the generator with a RunParameters object
 
-    void resetIntegrator();  ///< Reset integrator algorithm from the user-specified configuration
     void setIntegrator(std::unique_ptr<Integrator>);  ///< Specify an integrator algorithm configuration
-
-    void clearRun();  ///< Remove all references to a previous generation/run
-
-    void integrate();  ///< Integrate the functional over the phase space of interest
+    void integrate();                                 ///< Integrate the functional over the phase space of interest
 
     /// Compute the cross section for the run parameters
     /// \return The computed cross-section and uncertainty, in pb
@@ -123,7 +119,10 @@ namespace cepgen {
     double computePoint(const std::vector<double>& x);
 
   private:
-    void initialise();                           ///< Initialise event generation
+    void initialise();       ///< Initialise event generation
+    void clearRun();         ///< Remove all references to a previous generation/run
+    void resetIntegrator();  ///< Reset integrator algorithm from the user-specified configuration
+
     std::unique_ptr<RunParameters> parameters_;  ///< Run parameters for event generation and cross-section computation
     std::unique_ptr<GeneratorWorker> worker_;    ///< Generator worker instance
     std::unique_ptr<Integrator> integrator_;     ///< Integration algorithm

--- a/CepGen/Utils/Hist1D.cpp
+++ b/CepGen/Utils/Hist1D.cpp
@@ -240,5 +240,21 @@ namespace cepgen {
       }
       return gsl_histogram_pdf_sample(pdf_.get(), rng.uniform());
     }
+
+    double Hist1D::chi2test(const Hist1D& oth, size_t& ndfval) const {
+      if (nbins() != oth.nbins())
+        return 0.;
+      double chi2val = 0.;
+      ndfval = nbins();
+      for (size_t i = 0; i < nbins(); ++i) {
+        const auto bin_val1 = value(i), bin_val2 = oth.value(i);
+        if (bin_val1 == 0. && bin_val2 == 0.) {
+          --ndfval;
+          continue;
+        }
+        chi2val += std::pow((double)bin_val1 - (double)bin_val2, 2) / ((double)bin_val1 + (double)bin_val2);
+      }
+      return chi2val;
+    }
   }  // namespace utils
 }  // namespace cepgen

--- a/CepGen/Utils/Histogram.h
+++ b/CepGen/Utils/Histogram.h
@@ -89,6 +89,11 @@ namespace cepgen {
       /// Sample individual "events" from a distribution
       double sample(RandomGenerator&) const;
 
+      /// Perform a chi^2 test between two histograms
+      /// \param[out] ndf number of degrees of freedom (non-empty bins)
+      /// \return chi^2-value of the equivalence test
+      double chi2test(const Hist1D&, size_t& ndf) const;
+
       /// Retrieve the value + uncertainty for all bins
       std::vector<Value> values() const;
       /// Retrieve the value + uncertainty for one bin

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -132,10 +132,6 @@ public:
     // boost of the outgoing beams
     pX().setMass(mX());
     pY().setMass(mY());
-    if (beams_mode_ == mode::Kinematics::ElasticInelastic) {  // mirror X/Y and dilepton systems if needed
-      std::swap(pX(), pY());
-      std::swap(pc(0), pc(1));
-    }
     pX().betaGammaBoost(gamma_cm_, beta_gamma_cm_);
     pY().betaGammaBoost(gamma_cm_, beta_gamma_cm_);
     // incoming partons
@@ -150,6 +146,14 @@ public:
       mom->rotatePhi(ranphi, rany);
       if (symmetrise_ && mirror)
         mom->mirrorZ();
+    }
+    if (beams_mode_ == mode::Kinematics::ElasticInelastic) {  // mirror X/Y and dilepton systems if needed
+      std::swap(pX(), pY());
+      std::swap(pc(0), pc(1));
+      pX().mirrorZ();
+      pY().mirrorZ();
+      pc(0).mirrorZ();
+      pc(1).mirrorZ();
     }
     // first outgoing beam
     event()


### PR DESCRIPTION
This patch fixes the unexpected, but observed symmetry of the outgoing fermions and diffractive/elastic beam system kinematics in elastic-inelastic and inelastic-elastic modes, as reported in #57.

A z-mirroring of the 4-momenta of these two systems is therefore introduced.

To test this behaviour in future developments, a &chi;<sup>2</sup> test is performed on various differential distributions of interests in the test introduced in #28. Furthermore, the distributions can be shown when testing, e.g. for [the diffractive system mass](https://github.com/cepgen/cepgen/files/14537647/mdiff.pdf), the [leading lepton pseudo-rapidity](https://github.com/cepgen/cepgen/files/14537649/leading_eta.pdf), and the [subleading lepton pseudo-rapidity](https://github.com/cepgen/cepgen/files/14537648/subleading_eta.pdf).

Fixes #57