### PR TITLE
Signed PDG indices

### DIFF
--- a/CepGen/Core/ParametersList.cpp
+++ b/CepGen/Core/ParametersList.cpp
@@ -523,7 +523,7 @@ namespace cepgen {
     if (has<ParametersList>(key)) {  // first steer as a dictionary of particle properties
       const auto& plist = get<ParametersList>(key);
       if (plist.keys() == std::vector<std::string>{"pdgid"})
-        return PDG::get()(plist.get<pdgid_t>("pdgid"));
+        return PDG::get()(plist.get<int>("pdgid"));
       return ParticleProperties(plist);
     } else if (has<pdgid_t>(key) ||
                has<int>(key)) {  // if not a dictionary of properties, retrieve from PDG runtime database

--- a/CepGen/Core/ParametersList.cpp
+++ b/CepGen/Core/ParametersList.cpp
@@ -42,8 +42,8 @@
     return coll.count(key) != 0;                                                                                    \
   }                                                                                                                 \
   template <>                                                                                                       \
-  ParametersList& ParametersList::set<type>(std::string key, const type& value) {                                   \
-    coll[std::move(key)] = (type)(value);                                                                           \
+  ParametersList& ParametersList::set<type>(const std::string& key, const type& value) {                            \
+    coll[key] = static_cast<type>(value);                                                                           \
     return *this;                                                                                                   \
   }                                                                                                                 \
   template <>                                                                                                       \
@@ -414,7 +414,7 @@ namespace cepgen {
   }
 
   template <typename T>
-  ParametersList& ParametersList::set(std::string key, const T&) {
+  ParametersList& ParametersList::set(const std::string& key, const T&) {
     throw CG_FATAL("ParametersList") << "Invalid type to be set for key '" << key << "'.";
   }
 
@@ -537,9 +537,9 @@ namespace cepgen {
 
   /// Set a particle properties object value
   template <>
-  ParametersList& ParametersList::set<ParticleProperties>(std::string key, const ParticleProperties& value) {
+  ParametersList& ParametersList::set<ParticleProperties>(const std::string& key, const ParticleProperties& value) {
     PDG::get().define(value);
-    return set<ParametersList>(std::move(key), value.parameters());
+    return set<ParametersList>(key, value.parameters());
   }
 
   template <>

--- a/CepGen/Core/ParametersList.h
+++ b/CepGen/Core/ParametersList.h
@@ -26,19 +26,19 @@
 
 #include "CepGen/Utils/Limits.h"
 
-#define DEFINE_TYPE(type)                                                  \
-  template <>                                                              \
-  bool ParametersList::has<type>(const std::string&) const;                \
-  template <>                                                              \
-  type ParametersList::get<type>(const std::string&, const type&) const;   \
-  template <>                                                              \
-  type& ParametersList::operator[]<type>(const std::string&);              \
-  template <>                                                              \
-  ParametersList& ParametersList::set<type>(std::string key, const type&); \
-  template <>                                                              \
-  std::vector<std::string> ParametersList::keysOf<type>() const;           \
-  template <>                                                              \
-  size_t ParametersList::erase<type>(const std::string&);                  \
+#define DEFINE_TYPE(type)                                                     \
+  template <>                                                                 \
+  bool ParametersList::has<type>(const std::string&) const;                   \
+  template <>                                                                 \
+  type ParametersList::get<type>(const std::string&, const type&) const;      \
+  template <>                                                                 \
+  type& ParametersList::operator[]<type>(const std::string&);                 \
+  template <>                                                                 \
+  ParametersList& ParametersList::set<type>(const std::string&, const type&); \
+  template <>                                                                 \
+  std::vector<std::string> ParametersList::keysOf<type>() const;              \
+  template <>                                                                 \
+  size_t ParametersList::erase<type>(const std::string&);                     \
   static_assert(true, "")
 
 namespace cepgen {
@@ -114,11 +114,11 @@ namespace cepgen {
     T& operator[](const std::string& key);
     /// Set a parameter value
     template <typename T>
-    ParametersList& set(std::string key, const T& value);
+    ParametersList& set(const std::string&, const T&);
     /// Set a recast parameter value
     template <typename T, typename U>
-    inline ParametersList& setAs(std::string key, const U& value) {
-      return set<T>(std::move(key), static_cast<T>(value));
+    inline ParametersList& setAs(const std::string& key, const U& value) {
+      return set<T>(key, static_cast<T>(value));
     }
     /// Rename the key to a parameter value
     ParametersList& rename(const std::string& old_key, const std::string& new_key);

--- a/CepGen/Core/SteeredObject.h
+++ b/CepGen/Core/SteeredObject.h
@@ -56,6 +56,7 @@ namespace cepgen {
     REGISTER_TYPE(std::string, map_strs_)
     REGISTER_TYPE(Limits, map_lims_)
     REGISTER_TYPE(ParametersList, map_params_)
+    REGISTER_TYPE(std::vector<int>, map_vints_)
 
   public:
     /// Module user-defined parameters
@@ -73,6 +74,8 @@ namespace cepgen {
       for (const auto& kv : map_lims_)
         params_.set(kv.first, kv.second.get());
       for (const auto& kv : map_params_)
+        params_.set(kv.first, kv.second.get());
+      for (const auto& kv : map_vints_)
         params_.set(kv.first, kv.second.get());
       return params_;
     }
@@ -94,6 +97,8 @@ namespace cepgen {
         kv.second.get() = params_.operator[]<Limits>(kv.first);
       for (const auto& kv : map_params_)
         kv.second.get() = params_.operator[]<ParametersList>(kv.first);
+      for (const auto& kv : map_vints_)
+        kv.second.get() = params_.operator[]<std::vector<int> >(kv.first);
     }
   };
 }  // namespace cepgen

--- a/CepGen/Core/SteeredObject.h
+++ b/CepGen/Core/SteeredObject.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2021-2023  Laurent Forthomme
+ *  Copyright (C) 2021-2024  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,82 +23,76 @@
 
 #include "CepGen/Core/Steerable.h"
 
-#define REGISTER_TYPE(type, coll)                                \
-public:                                                          \
-  inline SteeredObject& add(const std::string& key, type& var) { \
-    coll.insert({key, std::ref(var)});                           \
-    var = params_.operator[]<type>(key);                         \
-    return *this;                                                \
-  }                                                              \
-                                                                 \
-private:                                                         \
-  std::unordered_map<std::string, std::reference_wrapper<type> > coll;
+#define REGISTER_TYPE(type, coll)                                      \
+public:                                                                \
+  inline SteeredObject& add(const std::string& key, type& var) {       \
+    coll.insert({key, std::ref(var)});                                 \
+    coll.at(key).get() = params_.operator[]<type>(key);                \
+    return *this;                                                      \
+  }                                                                    \
+                                                                       \
+private:                                                               \
+  std::unordered_map<std::string, std::reference_wrapper<type> > coll; \
+  static_assert(true, "")
 
 namespace cepgen {
   /// Base user-steerable object
+  /// \tparam T the type of object to be steered (using its T::description() static member)
   template <typename T>
   class SteeredObject : public Steerable {
   public:
     /// Build a module
-    SteeredObject() : Steerable(T::description().parameters()) {}
-    explicit SteeredObject(const ParametersList& params) : Steerable(T::description().validate(params)) {}
+    inline SteeredObject() : Steerable(T::description().parameters()) {}
+    explicit inline SteeredObject(const ParametersList& params) : Steerable(T::description().validate(params)) {}
     virtual ~SteeredObject() = default;
 
     /// Equality operator
-    bool operator==(const SteeredObject& oth) const { return parameters() == oth.parameters(); }
+    inline bool operator==(const SteeredObject& oth) const { return parameters() == oth.parameters(); }
     /// Inequality operator
-    bool operator!=(const SteeredObject& oth) const { return !operator==(oth); }
+    inline bool operator!=(const SteeredObject& oth) const { return !operator==(oth); }
 
-    REGISTER_TYPE(bool, map_bools_)
-    REGISTER_TYPE(int, map_ints_)
-    REGISTER_TYPE(unsigned long long, map_ulongs_)
-    REGISTER_TYPE(double, map_dbls_)
-    REGISTER_TYPE(std::string, map_strs_)
-    REGISTER_TYPE(Limits, map_lims_)
-    REGISTER_TYPE(ParametersList, map_params_)
-    REGISTER_TYPE(std::vector<int>, map_vints_)
+    REGISTER_TYPE(bool, map_bools_);
+    REGISTER_TYPE(int, map_ints_);
+    REGISTER_TYPE(unsigned long long, map_ulongs_);
+    REGISTER_TYPE(double, map_dbls_);
+    REGISTER_TYPE(std::string, map_strs_);
+    REGISTER_TYPE(Limits, map_lims_);
+    REGISTER_TYPE(ParametersList, map_params_);
+    REGISTER_TYPE(std::vector<int>, map_vints_);
 
   public:
     /// Module user-defined parameters
     inline const ParametersList& parameters() const override {
-      for (const auto& kv : map_bools_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_ints_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_ulongs_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_dbls_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_strs_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_lims_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_params_)
-        params_.set(kv.first, kv.second.get());
-      for (const auto& kv : map_vints_)
-        params_.set(kv.first, kv.second.get());
+      const auto set = [this](auto& map) {
+        for (const auto& kv : map)
+          params_.set(kv.first, kv.second.get());
+      };
+      set(map_bools_);
+      set(map_ints_);
+      set(map_ulongs_);
+      set(map_dbls_);
+      set(map_strs_);
+      set(map_lims_);
+      set(map_params_);
+      set(map_vints_);
       return params_;
     }
-    virtual void setParameters(const ParametersList& params) override {
+    virtual inline void setParameters(const ParametersList& params) override {
       if (params.empty())
         return;
       Steerable::setParameters(params);
-      for (const auto& kv : map_bools_)
-        kv.second.get() = params_.operator[]<bool>(kv.first);
-      for (const auto& kv : map_ints_)
-        kv.second.get() = params_.operator[]<int>(kv.first);
-      for (const auto& kv : map_ulongs_)
-        kv.second.get() = params_.operator[]<unsigned long long>(kv.first);
-      for (const auto& kv : map_dbls_)
-        kv.second.get() = params_.operator[]<double>(kv.first);
-      for (const auto& kv : map_strs_)
-        kv.second.get() = params_.operator[]<std::string>(kv.first);
-      for (const auto& kv : map_lims_)
-        kv.second.get() = params_.operator[]<Limits>(kv.first);
-      for (const auto& kv : map_params_)
-        kv.second.get() = params_.operator[]<ParametersList>(kv.first);
-      for (const auto& kv : map_vints_)
-        kv.second.get() = params_.operator[]<std::vector<int> >(kv.first);
+      const auto fill = [this](auto& map) {
+        for (const auto& kv : map)
+          params_.fill(kv.first, kv.second.get());
+      };
+      fill(map_bools_);
+      fill(map_ints_);
+      fill(map_ulongs_);
+      fill(map_dbls_);
+      fill(map_strs_);
+      fill(map_lims_);
+      fill(map_params_);
+      fill(map_vints_);
     }
   };
 }  // namespace cepgen

--- a/CepGen/Event/Particle.cpp
+++ b/CepGen/Event/Particle.cpp
@@ -116,12 +116,14 @@ namespace cepgen {
 
   pdgid_t Particle::pdgId() const { return pdg_id_; }
 
-  Particle& Particle::setPdgId(long pdg) {
+  Particle& Particle::setPdgId(pdgid_t pdg, short ch) { return setIntegerPdgId(pdg * (ch == 0 ? 1 : ch / abs(ch))); }
+
+  Particle& Particle::setIntegerPdgId(long pdg) {
     pdg_id_ = labs(pdg);
     if (PDG::get().has(pdg_id_)) {
       phys_prop_ = PDG::get()(pdg_id_);
-      CG_DEBUG("Particle:setPdgId") << "Particle PDG id set to " << pdg_id_ << ", "
-                                    << "properties set " << phys_prop_ << ".";
+      CG_DEBUG("Particle:setIntegerPdgId") << "Particle PDG id set to " << pdg_id_ << ", "
+                                           << "properties set " << phys_prop_ << ".";
     }
     switch (pdg_id_) {
       case 0:
@@ -139,13 +141,11 @@ namespace cepgen {
     return *this;
   }
 
-  Particle& Particle::setPdgId(pdgid_t pdg, short ch) { return setPdgId(long(pdg * (ch == 0 ? 1 : ch / abs(ch)))); }
-
-  int Particle::integerPdgId() const {
+  long Particle::integerPdgId() const {
     const float ch = phys_prop_.charge / 3.;
     if (ch == 0)
-      return static_cast<int>(pdg_id_);
-    return static_cast<int>(pdg_id_) * charge_sign_ * (ch / fabs(ch));
+      return static_cast<long>(pdg_id_);
+    return static_cast<long>(pdg_id_) * charge_sign_ * (ch / fabs(ch));
   }
 
   std::ostream& operator<<(std::ostream& os, const Particle& part) {

--- a/CepGen/Event/Particle.cpp
+++ b/CepGen/Event/Particle.cpp
@@ -53,7 +53,7 @@ namespace cepgen {
     return true;
   }
 
-  float Particle::charge() const { return charge_sign_ * phys_prop_.charge / 3.; }
+  float Particle::charge() const { return charge_sign_ * phys_prop_.integerCharge() / 3.; }
 
   Particle& Particle::clearMothers() {
     mothers_.clear();
@@ -142,7 +142,7 @@ namespace cepgen {
   }
 
   long Particle::integerPdgId() const {
-    const float ch = phys_prop_.charge / 3.;
+    const float ch = phys_prop_.integerCharge() / 3.;
     if (ch == 0)
       return static_cast<long>(pdg_id_);
     return static_cast<long>(pdg_id_) * charge_sign_ * (ch / fabs(ch));

--- a/CepGen/Event/Particle.h
+++ b/CepGen/Event/Particle.h
@@ -124,20 +124,19 @@ namespace cepgen {
     /// \param[in] pdg PDG identifier
     /// \param[in] ch Electric charge (0, 1, or -1)
     Particle& setPdgId(pdgid_t pdg, short ch = 0);
+    pdgid_t pdgId() const;  ///< Retrieve the objectified PDG identifier
     /// Set the PDG identifier (along with the particle's electric charge)
     /// \param[in] pdg_id PDG identifier (incl. electric charge in e)
-    Particle& setPdgId(long pdg_id);
-    /// Retrieve the objectified PDG identifier
-    pdgid_t pdgId() const;
-    /// Retrieve the integer value of the PDG identifier
-    int integerPdgId() const;
-    /// Particle's helicity
-    float helicity() const { return helicity_; }
+    Particle& setIntegerPdgId(long pdg_id);
+    long integerPdgId() const;  ///< Retrieve the integer value of the PDG identifier
+
+    float helicity() const { return helicity_; }  ///< Particle's helicity
     /// Set the helicity of the particle
     Particle& setHelicity(float heli) {
       helicity_ = heli;
       return *this;
     }
+
     /// Retrieve the momentum object associated with this particle
     inline Momentum& momentum() { return momentum_; }
     /// Retrieve the momentum object associated with this particle

--- a/CepGen/Physics/Beam.h
+++ b/CepGen/Physics/Beam.h
@@ -48,9 +48,9 @@ namespace cepgen {
       elastic_ = el;
       return *this;
     }
-    pdgid_t pdgId() const { return pdg_id_; }  ///< Beam particle PDG id
+    spdgid_t integerPdgId() const { return pdg_id_; }  ///< Beam particle PDG id
     /// Set the beam particle PDG id
-    Beam& setPdgId(pdgid_t pdg) {
+    Beam& setIntegerPdgId(spdgid_t pdg) {
       pdg_id_ = pdg;
       return *this;
     }
@@ -63,7 +63,7 @@ namespace cepgen {
     const ParametersList& partonFluxParameters() const { return flux_info_; }
 
   private:
-    pdgid_t pdg_id_{0};         ///< PDG identifier for the beam
+    spdgid_t pdg_id_{0};        ///< PDG identifier for the beam
     Momentum momentum_;         ///< Incoming particle momentum
     ParametersList flux_info_;  ///< Incoming parton flux parameters
     bool elastic_;              ///< Elastic parton emission?

--- a/CepGen/Physics/HeavyIon.cpp
+++ b/CepGen/Physics/HeavyIon.cpp
@@ -51,7 +51,8 @@ namespace cepgen {
     return (pdgid_t)(10'000'000 + 1000 * (unsigned short)Z + A);
   }
 
-  bool HeavyIon::isHI(const pdgid_t& pdgid) { return pdgid / 10'000'000 != 0; }
+  bool HeavyIon::isHI(const spdgid_t& pdgid) { return pdgid / 10'000'000 != 0; }
+
   bool HeavyIon::isHI(const ParticleProperties& prop) {
     return isHI(prop.pdgid);  //FIXME can refine a bit
   }

--- a/CepGen/Physics/HeavyIon.h
+++ b/CepGen/Physics/HeavyIon.h
@@ -60,7 +60,7 @@ namespace cepgen {
     /// Build from a custom PDG id
     static HeavyIon fromPdgId(pdgid_t);
     /// Check if the PDG id is compatible with a HI
-    static bool isHI(const pdgid_t&);
+    static bool isHI(const spdgid_t&);
     /// Check if the particle properties are compatible with a HI
     static bool isHI(const ParticleProperties&);
     /// Mass of a heavy ion, in GeV/c\f$^2\f$

--- a/CepGen/Physics/MCDFileParser.cpp
+++ b/CepGen/Physics/MCDFileParser.cpp
@@ -36,8 +36,7 @@ namespace pdg {
     while (std::getline(ifile, line)) {
       if (line[0] == '*')  // skip comments
         continue;
-      std::vector<int> pdg_ids;
-      std::vector<short> charges;
+      std::vector<int> pdg_ids, charges;
       double mass, width;
       std::string part_name;
       {  // pdg ids
@@ -91,10 +90,10 @@ namespace pdg {
       prop.colours = 1;
       prop.mass = mass;
       prop.width = width;
+      prop.charges = charges;
       prop.fermion = false;
       for (size_t i = 0; i < pdg_ids.size(); ++i) {
         prop.pdgid = (cepgen::pdgid_t)pdg_ids.at(i);
-        prop.charge = charges.at(i);
         switch (pdg_ids.at(i)) {
           // start with quarks
           case 1:

--- a/CepGen/Physics/MCDFileParser.cpp
+++ b/CepGen/Physics/MCDFileParser.cpp
@@ -94,7 +94,7 @@ namespace pdg {
       for (size_t i = 0; i < pdg_ids.size(); ++i) {
         prop.pdgid = (cepgen::pdgid_t)pdg_ids.at(i);
         if (const auto ch = charges.at(i); ch != 0)
-          prop.charges = {-std::abs(ch), +std::abs(ch)};
+          prop.charges = {ch, -ch};
         switch (pdg_ids.at(i)) {
           // start with quarks
           case 1:

--- a/CepGen/Physics/MCDFileParser.cpp
+++ b/CepGen/Physics/MCDFileParser.cpp
@@ -90,10 +90,11 @@ namespace pdg {
       prop.colours = 1;
       prop.mass = mass;
       prop.width = width;
-      prop.charges = charges;
       prop.fermion = false;
       for (size_t i = 0; i < pdg_ids.size(); ++i) {
         prop.pdgid = (cepgen::pdgid_t)pdg_ids.at(i);
+        if (const auto ch = charges.at(i); ch != 0)
+          prop.charges = {-std::abs(ch), +std::abs(ch)};
         switch (pdg_ids.at(i)) {
           // start with quarks
           case 1:

--- a/CepGen/Physics/PDG.cpp
+++ b/CepGen/Physics/PDG.cpp
@@ -91,7 +91,7 @@ namespace cepgen {
 
   double PDG::width(spdgid_t id) const { return operator()(id).width; }
 
-  double PDG::charge(spdgid_t id) const { return operator()(id).integerCharge() * 1. / 3.; }
+  double PDG::charge(spdgid_t id) const { return operator()(id).integerCharge() * (id / std::abs(id)) * 1. / 3.; }
 
   std::vector<double> PDG::charges(spdgid_t id) const {
     std::vector<double> chs;

--- a/CepGen/Physics/PDG.cpp
+++ b/CepGen/Physics/PDG.cpp
@@ -28,10 +28,10 @@ namespace cepgen {
 
   PDG::PDG() {
     // PDG id, name, description, colour, mass, width, charge, is fermion
-    define(ParticleProperties(invalid, "invalid", "invalid", 0, -1., -1., 0, false));
-    define(ParticleProperties(diffractiveProton, "diff_proton", "p\u002A", 0, 0., 0., 3, false));
-    define(ParticleProperties(pomeron, "pomeron", "\u2119", 0, 0., 0., 0, false));
-    define(ParticleProperties(reggeon, "reggeon", "\u211D", 0, 0., 0., 0, false));
+    define(ParticleProperties(invalid, "invalid", "invalid", 0, -1., -1., {}, false));
+    define(ParticleProperties(diffractiveProton, "diff_proton", "p\u002A", 0, 0., 0., {3}, false));
+    define(ParticleProperties(pomeron, "pomeron", "\u2119", 0, 0., 0., {0}, false));
+    define(ParticleProperties(reggeon, "reggeon", "\u211D", 0, 0., 0., {0}, false));
   }
 
   PDG& PDG::get() {
@@ -91,7 +91,7 @@ namespace cepgen {
 
   double PDG::width(pdgid_t id) const { return operator()(id).width; }
 
-  double PDG::charge(pdgid_t id) const { return operator()(id).charge * 1. / 3.; }
+  double PDG::charge(pdgid_t id) const { return operator()(id).integerCharge() * 1. / 3.; }
 
   size_t PDG::size() const { return particles_.size(); }
 
@@ -115,7 +115,7 @@ namespace cepgen {
             "\n%20s %-32s\tcharge: %2de, colour factor: %1d, mass: %8.4f GeV/c^2, width: %6.3f GeV.",
             utils::colourise(std::to_string(prt.second.pdgid), utils::Colour::none, utils::Modifier::italic).data(),
             (utils::boldify(prt.second.name) + " " + (prt.second.fermion ? "fermion" : "boson") + ":").data(),
-            prt.second.charge / 3,
+            prt.second.charges,
             prt.second.colours,
             prt.second.mass,
             prt.second.width);

--- a/CepGen/Physics/PDG.cpp
+++ b/CepGen/Physics/PDG.cpp
@@ -39,10 +39,10 @@ namespace cepgen {
     return instance;
   }
 
-  bool PDG::has(pdgid_t id) const { return particles_.count(id) > 0; }
+  bool PDG::has(spdgid_t id) const { return particles_.count(std::abs(id)) > 0; }
 
-  const ParticleProperties& PDG::operator()(pdgid_t id) const {
-    auto it = particles_.find(id);
+  const ParticleProperties& PDG::operator()(spdgid_t id) const {
+    auto it = particles_.find(std::abs(id));
     if (it != particles_.end())
       return it->second;
     throw CG_FATAL("PDG").log([this, &id](auto& log) {
@@ -51,7 +51,7 @@ namespace cepgen {
     });
   }
 
-  ParticleProperties& PDG::operator[](pdgid_t id) { return particles_[id]; }
+  ParticleProperties& PDG::operator[](spdgid_t id) { return particles_[std::abs(id)]; }
 
   void PDG::define(const ParticleProperties& props) {
     if (props.pdgid == PDG::invalid && props.name != "invalid")
@@ -74,24 +74,24 @@ namespace cepgen {
     return out;
   }
 
-  const std::string& PDG::name(pdgid_t id) const {
+  const std::string& PDG::name(spdgid_t id) const {
     const auto& descr = operator()(id).descr;
     if (!descr.empty())
       return descr;
     return operator()(id).name;
   }
 
-  double PDG::colours(pdgid_t id) const { return operator()(id).colours; }
+  double PDG::colours(spdgid_t id) const { return operator()(id).colours; }
 
-  double PDG::mass(pdgid_t id) const {
+  double PDG::mass(spdgid_t id) const {
     if (HeavyIon::isHI(id))
       return HeavyIon::fromPdgId(id).mass();
     return operator()(id).mass;
   }
 
-  double PDG::width(pdgid_t id) const { return operator()(id).width; }
+  double PDG::width(spdgid_t id) const { return operator()(id).width; }
 
-  double PDG::charge(pdgid_t id) const { return operator()(id).integerCharge() * 1. / 3.; }
+  double PDG::charge(spdgid_t id) const { return operator()(id).integerCharge() * 1. / 3.; }
 
   size_t PDG::size() const { return particles_.size(); }
 

--- a/CepGen/Physics/PDG.cpp
+++ b/CepGen/Physics/PDG.cpp
@@ -29,9 +29,9 @@ namespace cepgen {
   PDG::PDG() {
     // PDG id, name, description, colour, mass, width, charge, is fermion
     define(ParticleProperties(invalid, "invalid", "invalid", 0, -1., -1., {}, false));
-    define(ParticleProperties(diffractiveProton, "diff_proton", "p\u002A", 0, 0., 0., {3}, false));
-    define(ParticleProperties(pomeron, "pomeron", "\u2119", 0, 0., 0., {0}, false));
-    define(ParticleProperties(reggeon, "reggeon", "\u211D", 0, 0., 0., {0}, false));
+    define(ParticleProperties(diffractiveProton, "diff_proton", "p\u002A", 0, 0., 0., {-3, 3}, false));
+    define(ParticleProperties(pomeron, "pomeron", "\u2119", 0, 0., 0., {}, false));
+    define(ParticleProperties(reggeon, "reggeon", "\u211D", 0, 0., 0., {}, false));
   }
 
   PDG& PDG::get() {
@@ -93,6 +93,13 @@ namespace cepgen {
 
   double PDG::charge(spdgid_t id) const { return operator()(id).integerCharge() * 1. / 3.; }
 
+  std::vector<double> PDG::charges(spdgid_t id) const {
+    std::vector<double> chs;
+    for (const auto& ch : operator()(id).charges)
+      chs.emplace_back(ch * 1. / 3);
+    return chs;
+  }
+
   size_t PDG::size() const { return particles_.size(); }
 
   void PDG::dump(std::ostream* os) const {
@@ -112,10 +119,10 @@ namespace cepgen {
     for (const auto& prt : tmp)
       if (prt.first != PDG::invalid)
         oss << utils::format(
-            "\n%20s %-32s\tcharge: %2de, colour factor: %1d, mass: %8.4f GeV/c^2, width: %6.3f GeV.",
+            "\n%16s %-32s\tcharges: {%6s}, colour factor: %1d, mass: %8.4f GeV/c^2, width: %6.3f GeV.",
             utils::colourise(std::to_string(prt.second.pdgid), utils::Colour::none, utils::Modifier::italic).data(),
             (utils::boldify(prt.second.name) + " " + (prt.second.fermion ? "fermion" : "boson") + ":").data(),
-            prt.second.charges,
+            utils::merge(prt.second.charges, ",").data(),
             prt.second.colours,
             prt.second.mass,
             prt.second.width);

--- a/CepGen/Physics/PDG.h
+++ b/CepGen/Physics/PDG.h
@@ -89,6 +89,8 @@ namespace cepgen {
     double mass(spdgid_t) const;                           ///< Particle mass (in GeV)
     double width(spdgid_t) const;                          ///< Resonance width (in GeV)
     double charge(spdgid_t) const;                         ///< Electric charge (in \f$e\f$) for this particle
+    /// Electric charges (in \f$e\f$) for this particle (and its potential anti-particles)
+    std::vector<double> charges(spdgid_t) const;
 
   private:
     explicit PDG();

--- a/CepGen/Physics/PDG.h
+++ b/CepGen/Physics/PDG.h
@@ -81,14 +81,14 @@ namespace cepgen {
 
     //--- per-particles information
 
-    bool has(pdgid_t) const;                              ///< Is the particle defined for a given PDG id
-    const ParticleProperties& operator()(pdgid_t) const;  ///< All physical properties for one particle
-    ParticleProperties& operator[](pdgid_t id);           /// Accessor for particle properties
-    const std::string& name(pdgid_t) const;               ///< Human-readable name for this particle
-    double colours(pdgid_t) const;                        ///< Colour factor for this particle
-    double mass(pdgid_t) const;                           ///< Particle mass (in GeV)
-    double width(pdgid_t) const;                          ///< Resonance width (in GeV)
-    double charge(pdgid_t) const;                         ///< Electric charge (in \f$e\f$) for this particle
+    bool has(spdgid_t) const;                              ///< Is the particle defined for a given PDG id
+    const ParticleProperties& operator()(spdgid_t) const;  ///< All physical properties for one particle
+    ParticleProperties& operator[](spdgid_t id);           /// Accessor for particle properties
+    const std::string& name(spdgid_t) const;               ///< Human-readable name for this particle
+    double colours(spdgid_t) const;                        ///< Colour factor for this particle
+    double mass(spdgid_t) const;                           ///< Particle mass (in GeV)
+    double width(spdgid_t) const;                          ///< Resonance width (in GeV)
+    double charge(spdgid_t) const;                         ///< Electric charge (in \f$e\f$) for this particle
 
   private:
     explicit PDG();
@@ -98,4 +98,3 @@ namespace cepgen {
 }  // namespace cepgen
 
 #endif
-

--- a/CepGen/Physics/ParticleProperties.cpp
+++ b/CepGen/Physics/ParticleProperties.cpp
@@ -31,7 +31,7 @@ namespace cepgen {
         .add("colours", colours)
         .add("mass", mass)
         .add("width", width)
-        .add("charges", charges)
+        //.add("charges", charges)  // we disable this for the time being
         .add("fermion", fermion);
   }
 

--- a/CepGen/Physics/ParticleProperties.cpp
+++ b/CepGen/Physics/ParticleProperties.cpp
@@ -17,7 +17,6 @@
  */
 
 #include <iostream>
-#include <set>
 
 #include "CepGen/Core/Exception.h"
 #include "CepGen/Physics/ParticleProperties.h"
@@ -57,13 +56,10 @@ namespace cepgen {
   short ParticleProperties::integerCharge() const {
     if (charges.empty())
       return 0;
-    std::set<short> abs_charges;
-    for (const auto& ch : charges)
-      abs_charges.insert(std::abs(ch));
-    if (abs_charges.size() > 1)
+    if (charges.size() > 2)
       throw CG_ERROR("ParticleProperties:integerCharge")
-          << "Multiple charges are possible for the given particle: " << abs_charges << ".";
-    return *abs_charges.begin();
+          << "Multiple charges are possible for the given particle: " << charges << ".";
+    return charges.at(0);
   }
 
   ParametersDescription ParticleProperties::description() {

--- a/CepGen/Physics/ParticleProperties.h
+++ b/CepGen/Physics/ParticleProperties.h
@@ -29,6 +29,8 @@ namespace cepgen {
   /// Alias for the integer-like particle PDG id
   typedef unsigned long long pdgid_t;
   typedef std::vector<pdgid_t> pdgids_t;
+  typedef long long spdgid_t;
+  typedef std::vector<spdgid_t> spdgids_t;
   /// A collection of physics constants associated to a single particle
   struct ParticleProperties final : SteeredObject<ParticleProperties> {
     explicit ParticleProperties(const ParametersList&);
@@ -38,21 +40,23 @@ namespace cepgen {
                                 int pcolours = -1,
                                 double pmass = -1.,
                                 double pwidth = -1.,
-                                int pcharge = 0.,
+                                const std::vector<int>& pcharges = {},
                                 bool pfermion = false);
 
     static ParametersDescription description();
 
     friend std::ostream& operator<<(std::ostream&, const ParticleProperties&);
 
-    pdgid_t pdgid{0ull};  ///< PDG identifier
-    std::string name{};   ///< Particle name
-    std::string descr{};  ///< Human-readable name
-    int colours{0};       ///< Colour factor
-    double mass{0.};      ///< Mass, in GeV/c\f$^2\f$
-    double width{0.};     ///< Decay width, in GeV/c\f$^2\f$
-    int charge{0};        ///< Electric charge, in \f$e\f$/3
-    bool fermion{false};  ///< Is the particle a fermion?
+    short integerCharge() const;  ///< Integer charge, in \f$e\f$/3
+
+    pdgid_t pdgid{0ull};       ///< PDG identifier
+    std::string name{};        ///< Particle name
+    std::string descr{};       ///< Human-readable name
+    int colours{0};            ///< Colour factor
+    double mass{0.};           ///< Mass, in GeV/c\f$^2\f$
+    double width{0.};          ///< Decay width, in GeV/c\f$^2\f$
+    std::vector<int> charges;  ///< Electric charges, in \f$e\f$/3
+    bool fermion{false};       ///< Is the particle a fermion?
   };
 }  // namespace cepgen
 

--- a/CepGen/Physics/ParticleProperties.h
+++ b/CepGen/Physics/ParticleProperties.h
@@ -49,14 +49,14 @@ namespace cepgen {
 
     short integerCharge() const;  ///< Integer charge, in \f$e\f$/3
 
-    pdgid_t pdgid{0ull};       ///< PDG identifier
-    std::string name{};        ///< Particle name
-    std::string descr{};       ///< Human-readable name
-    int colours{0};            ///< Colour factor
-    double mass{0.};           ///< Mass, in GeV/c\f$^2\f$
-    double width{0.};          ///< Decay width, in GeV/c\f$^2\f$
-    std::vector<int> charges;  ///< Electric charges, in \f$e\f$/3
-    bool fermion{false};       ///< Is the particle a fermion?
+    pdgid_t pdgid{0ull};         ///< PDG identifier
+    std::string name{};          ///< Particle name
+    std::string descr{};         ///< Human-readable name
+    int colours{0};              ///< Colour factor
+    double mass{0.};             ///< Mass, in GeV/c\f$^2\f$
+    double width{0.};            ///< Decay width, in GeV/c\f$^2\f$
+    std::vector<int> charges{};  ///< Electric charges, in \f$e\f$/3
+    bool fermion{false};         ///< Is the particle a fermion?
   };
 }  // namespace cepgen
 

--- a/CepGen/Physics/ParticleProperties.h
+++ b/CepGen/Physics/ParticleProperties.h
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2017-2023  Laurent Forthomme
+ *  Copyright (C) 2017-2024  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -34,14 +34,14 @@ namespace cepgen {
   /// A collection of physics constants associated to a single particle
   struct ParticleProperties final : SteeredObject<ParticleProperties> {
     explicit ParticleProperties(const ParametersList&);
-    explicit ParticleProperties(pdgid_t ppdgid = 0ull,  // PDG::invalid
-                                const std::string& pname = "",
-                                const std::string& pdescr = "",
-                                int pcolours = -1,
-                                double pmass = -1.,
-                                double pwidth = -1.,
-                                const std::vector<int>& pcharges = {},
-                                bool pfermion = false);
+    explicit ParticleProperties(pdgid_t pdgid = 0ull,  // PDG::invalid
+                                const std::string& name = "",
+                                const std::string& descr = "",
+                                int colours = -1,
+                                double mass = -1.,
+                                double width = -1.,
+                                const std::vector<int>& charges = {},
+                                bool fermion = false);
 
     static ParametersDescription description();
 

--- a/CepGen/Process/FactorisedProcess.cpp
+++ b/CepGen/Process/FactorisedProcess.cpp
@@ -27,7 +27,7 @@
 
 namespace cepgen {
   namespace proc {
-    FactorisedProcess::FactorisedProcess(const ParametersList& params, const pdgids_t& central)
+    FactorisedProcess::FactorisedProcess(const ParametersList& params, const spdgids_t& central)
         : Process(params),
           psgen_(PhaseSpaceGeneratorFactory::get().build(
               steer<ParametersList>("kinematicsGenerator")

--- a/CepGen/Process/FactorisedProcess.cpp
+++ b/CepGen/Process/FactorisedProcess.cpp
@@ -42,11 +42,13 @@ namespace cepgen {
           store_alphas_(proc.store_alphas_) {}
 
     void FactorisedProcess::addEventContent() {
-      Process::setEventContent({{Particle::IncomingBeam1, {kinematics().incomingBeams().positive().pdgId()}},
-                                {Particle::IncomingBeam2, {kinematics().incomingBeams().negative().pdgId()}},
-                                {Particle::OutgoingBeam1, {kinematics().incomingBeams().positive().pdgId()}},
-                                {Particle::OutgoingBeam2, {kinematics().incomingBeams().negative().pdgId()}},
-                                {Particle::CentralSystem, psgen_->central()}});
+      CG_ASSERT(psgen_);
+      const auto cent_pdgids = psgen_->central();
+      Process::setEventContent({{Particle::IncomingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
+                                {Particle::IncomingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
+                                {Particle::OutgoingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
+                                {Particle::OutgoingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
+                                {Particle::CentralSystem, spdgids_t(cent_pdgids.begin(), cent_pdgids.end())}});
     }
 
     void FactorisedProcess::prepareKinematics() {

--- a/CepGen/Process/FactorisedProcess.h
+++ b/CepGen/Process/FactorisedProcess.h
@@ -35,7 +35,7 @@ namespace cepgen {
       /// Class constructor
       /// \param[in] params Parameters list
       /// \param[in] output Produced final state particles
-      explicit FactorisedProcess(const ParametersList& params, const pdgids_t& output);
+      explicit FactorisedProcess(const ParametersList& params, const spdgids_t& output);
       FactorisedProcess(const FactorisedProcess&);
 
       double computeWeight() override;

--- a/CepGen/Process/FortranFactorisedProcess.cpp
+++ b/CepGen/Process/FortranFactorisedProcess.cpp
@@ -120,8 +120,8 @@ namespace cepgen {
       //--- positive-z incoming beam
       genparams_.inp1 = kinematics().incomingBeams().positive().momentum().pz();
       //--- check if first incoming beam is a heavy ion
-      if (HeavyIon::isHI(kinematics().incomingBeams().positive().pdgId())) {
-        const auto in1 = HeavyIon::fromPdgId(kinematics().incomingBeams().positive().pdgId());
+      if (HeavyIon::isHI(kinematics().incomingBeams().positive().integerPdgId())) {
+        const auto in1 = HeavyIon::fromPdgId(kinematics().incomingBeams().positive().integerPdgId());
         genparams_.a_nuc1 = in1.A;
         genparams_.z_nuc1 = (unsigned short)in1.Z;
         if (genparams_.z_nuc1 > 1) {
@@ -134,8 +134,8 @@ namespace cepgen {
       //--- negative-z incoming beam
       genparams_.inp2 = kinematics().incomingBeams().negative().momentum().pz();
       //--- check if second incoming beam is a heavy ion
-      if (HeavyIon::isHI(kinematics().incomingBeams().negative().pdgId())) {
-        const auto in2 = HeavyIon::fromPdgId(kinematics().incomingBeams().negative().pdgId());
+      if (HeavyIon::isHI(kinematics().incomingBeams().negative().integerPdgId())) {
+        const auto in2 = HeavyIon::fromPdgId(kinematics().incomingBeams().negative().integerPdgId());
         genparams_.a_nuc2 = in2.A;
         genparams_.z_nuc2 = (unsigned short)in2.Z;
         if (genparams_.z_nuc2 > 1) {

--- a/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
+++ b/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
@@ -47,7 +47,7 @@ namespace cepgen {
           "EPAFlux", ParametersList().set("formFactors", ParametersList().setName<std::string>("HeavyIonDipole")));
       if (params.name<std::string>().empty()) {
         if (beam.elastic()) {
-          if (HeavyIon::isHI(beam.pdgId()))
+          if (HeavyIon::isHI(beam.integerPdgId()))
             params = params_hi_el.validate(params);
           else
             params = params_p_el.validate(params);

--- a/CepGen/Process/PartonsKTPhaseSpaceGenerator.cpp
+++ b/CepGen/Process/PartonsKTPhaseSpaceGenerator.cpp
@@ -39,7 +39,7 @@ namespace cepgen {
       const auto params_hi_el = KTFluxFactory::get().describeParameters("ElasticHeavyIon");
       if (params.name<std::string>().empty()) {
         if (beam.elastic()) {
-          if (HeavyIon::isHI(beam.pdgId()))
+          if (HeavyIon::isHI(beam.integerPdgId()))
             params = params_hi_el.validate(params);
           else
             params = params_p_el.validate(params);

--- a/CepGen/Process/PhaseSpaceGenerator.h
+++ b/CepGen/Process/PhaseSpaceGenerator.h
@@ -43,8 +43,9 @@ namespace cepgen {
     virtual bool generate() = 0;        ///< Generate a kinematics combination, and return a success flag
     virtual double weight() const = 0;  ///< Return the event weight for a kinematics combination
 
-    virtual pdgids_t partons() const = 0;  ///< List of incoming partons in kinematics
-    virtual pdgids_t central() const = 0;  ///< List of outgoing central particles in kinematics
+    virtual pdgids_t partons() const = 0;                  ///< List of incoming partons in kinematics
+    virtual void setCentral(const std::vector<int>&) = 0;  ///< Override the central particles list
+    virtual std::vector<int> central() const = 0;          ///< List of outgoing central particles in kinematics
 
     // Mandelstam variables
     virtual double that() const = 0;

--- a/CepGen/Process/PhaseSpaceGenerator2to4.cpp
+++ b/CepGen/Process/PhaseSpaceGenerator2to4.cpp
@@ -37,10 +37,7 @@ namespace cepgen {
   class PhaseSpaceGenerator2to4 : public PhaseSpaceGenerator {
   public:
     explicit PhaseSpaceGenerator2to4(const ParametersList& params)
-        : PhaseSpaceGenerator(params),
-          part_psgen_(new T(params)),
-          int_particles_(steer<std::vector<int> >("ids")),
-          particles_(int_particles_.begin(), int_particles_.end()) {}
+        : PhaseSpaceGenerator(params), part_psgen_(new T(params)), particles_(steer<std::vector<int> >("ids")) {}
 
     static ParametersDescription description() {
       auto desc = PhaseSpaceGenerator::description();
@@ -99,7 +96,9 @@ namespace cepgen {
       return pdgids_t{part_psgen_->positiveFlux().partonPdgId(), part_psgen_->negativeFlux().partonPdgId()};
     }
 
-    pdgids_t central() const override { return particles_; }
+    std::vector<int> central() const override { return particles_; }
+
+    void setCentral(const std::vector<int>& cent) override { particles_ = cent; }
 
     double that() const override {
       return 0.5 * ((proc_->q1() - proc_->pc(0)).mass2() + (proc_->q2() - proc_->pc(1)).mass2());
@@ -208,8 +207,7 @@ namespace cepgen {
     static constexpr double NUM_LIMITS = 1.e-3;  ///< Numerical limits for sanity comparisons (MeV/mm-level)
 
     const std::unique_ptr<PartonsPhaseSpaceGenerator> part_psgen_;
-    const std::vector<int> int_particles_;  ///< Type of particles produced in the final state (integer values)
-    const pdgids_t particles_;              ///< Type of particles produced in the final state (PDG ids)
+    std::vector<int> particles_;  ///< Type of particles produced in the final state (integer values)
 
     proc::FactorisedProcess* proc_{nullptr};  //NOT owning
 

--- a/CepGen/Process/Process.cpp
+++ b/CepGen/Process/Process.cpp
@@ -304,17 +304,17 @@ namespace cepgen {
       //--- define incoming system
       if (event_) {
         auto& ib1 = event_->oneWithRole(Particle::IncomingBeam1);
-        ib1.setPdgId(kin_.incomingBeams().positive().pdgId());
+        ib1.setPdgId(kin_.incomingBeams().positive().integerPdgId());
         ib1.setMomentum(p1);
         auto& ib2 = event_->oneWithRole(Particle::IncomingBeam2);
-        ib2.setPdgId(kin_.incomingBeams().negative().pdgId());
+        ib2.setPdgId(kin_.incomingBeams().negative().integerPdgId());
         ib2.setMomentum(p2);
         auto& ob1 = event_->oneWithRole(Particle::OutgoingBeam1);
-        ob1.setPdgId(kin_.incomingBeams().positive().pdgId());
+        ob1.setPdgId(kin_.incomingBeams().positive().integerPdgId());
         ob1.setStatus(kin_.incomingBeams().positive().elastic() ? Particle::Status::FinalState
                                                                 : Particle::Status::Unfragmented);
         auto& ob2 = event_->oneWithRole(Particle::OutgoingBeam2);
-        ob2.setPdgId(kin_.incomingBeams().negative().pdgId());
+        ob2.setPdgId(kin_.incomingBeams().negative().integerPdgId());
         ob2.setStatus(kin_.incomingBeams().negative().elastic() ? Particle::Status::FinalState
                                                                 : Particle::Status::Unfragmented);
         for (auto& cp : (*event_)[Particle::CentralSystem])
@@ -372,7 +372,7 @@ namespace cepgen {
         (*os) << oss.str();
     }
 
-    void Process::setEventContent(const std::unordered_map<Particle::Role, pdgids_t>& part_ids) {
+    void Process::setEventContent(const std::unordered_map<Particle::Role, spdgids_t>& part_ids) {
       if (!event_)
         return;
       if (part_ids.count(Particle::Role::CentralSystem) == 0)
@@ -393,7 +393,7 @@ namespace cepgen {
             evt_part.momentum().setMass(HeavyIon::fromPdgId(user_evt_part_pdgid).mass());
           } else {
             const auto& part_info = PDG::get()(user_evt_part_pdgid);
-            evt_part.setPdgId(user_evt_part_pdgid, part_info.charge / 3.);
+            evt_part.setIntegerPdgId(user_evt_part_pdgid);
             evt_part.momentum().setMass(part_info.mass);
           }
         }

--- a/CepGen/Process/Process.h
+++ b/CepGen/Process/Process.h
@@ -160,7 +160,7 @@ namespace cepgen {
       double generateVariables() const;
 
       /// Set the incoming and outgoing states to be defined in this process (and prepare the Event object accordingly)
-      void setEventContent(const std::unordered_map<Particle::Role, pdgids_t>&);
+      void setEventContent(const std::unordered_map<Particle::Role, spdgids_t>&);
 
       double alphaEM(double q) const;  ///< Compute the electromagnetic running coupling algorithm at a given scale
       double alphaS(double q) const;   ///< Compute the strong coupling algorithm at a given scale

--- a/CepGenAddOns/HepMC3Wrapper/LHEFHepMCHandler.cpp
+++ b/CepGenAddOns/HepMC3Wrapper/LHEFHepMCHandler.cpp
@@ -89,8 +89,8 @@ namespace cepgen {
     void initialise() override {
       lhe_output_->headerBlock() << "<!--\n" << banner() << "\n-->";
       if (runParameters().hasProcess()) {  // run information only specified if process (and kinematics) is specified
-        lhe_output_->heprup.IDBMUP = {(int)runParameters().kinematics().incomingBeams().positive().pdgId(),
-                                      (int)runParameters().kinematics().incomingBeams().negative().pdgId()};
+        lhe_output_->heprup.IDBMUP = {(int)runParameters().kinematics().incomingBeams().positive().integerPdgId(),
+                                      (int)runParameters().kinematics().incomingBeams().negative().integerPdgId()};
         lhe_output_->heprup.EBMUP = {(double)runParameters().kinematics().incomingBeams().positive().momentum().pz(),
                                      (double)runParameters().kinematics().incomingBeams().negative().momentum().pz()};
       }

--- a/CepGenAddOns/ProMCWrapper/ProMCHandler.cpp
+++ b/CepGenAddOns/ProMCWrapper/ProMCHandler.cpp
@@ -91,8 +91,8 @@ namespace cepgen {
         data->set_width(desc.width);
         data->set_charge(desc.charge * 1. / 3.);
       }
-      hdr.set_id1(runParameters().kinematics().incomingBeams().positive().pdgId());
-      hdr.set_id2(runParameters().kinematics().incomingBeams().negative().pdgId());
+      hdr.set_id1(runParameters().kinematics().incomingBeams().positive().integerPdgId());
+      hdr.set_id2(runParameters().kinematics().incomingBeams().negative().integerPdgId());
       hdr.set_pdf1(0);
       hdr.set_pdf2(0);
       hdr.set_x1(0);

--- a/CepGenAddOns/Pythia6Wrapper/Pythia6Interface.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/Pythia6Interface.cpp
@@ -122,8 +122,9 @@ namespace pythia6 {
     prop.descr = name;
     //prop.colours = pyk(p + 1, 12);  // colour factor
     prop.mass = pymass(pdg_id);
-    prop.width = -1.;              //pmas( pdg_id, 2 ),
-    prop.charge = pychge(pdg_id);  // charge
+    prop.width = -1.;  //pmas( pdg_id, 2 ),
+    if (const auto ch = pychge(pdg_id); std::fabs(ch) > 0)
+      prop.charges = {+std::abs(int(ch * 3.)), -std::abs(int(ch * 3.))};
     prop.fermion = false;
     cepgen::PDG::get().define(prop);
   }

--- a/CepGenAddOns/Pythia6Wrapper/Pythia6Interface.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/Pythia6Interface.cpp
@@ -124,7 +124,7 @@ namespace pythia6 {
     prop.mass = pymass(pdg_id);
     prop.width = -1.;  //pmas( pdg_id, 2 ),
     if (const auto ch = pychge(pdg_id); std::fabs(ch) > 0)
-      prop.charges = {+std::abs(int(ch * 3.)), -std::abs(int(ch * 3.))};
+      prop.charges = {-std::abs(int(ch * 3.)), +std::abs(int(ch * 3.))};
     prop.fermion = false;
     cepgen::PDG::get().define(prop);
   }

--- a/CepGenAddOns/Pythia6Wrapper/Pythia6Interface.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/Pythia6Interface.cpp
@@ -40,7 +40,7 @@ extern void pyname_(int&, char*, int);
 extern int pyk_(int&, int&);
 /// Get real-valued event information from Pythia
 extern double pyp_(int&, int&);
-extern double pychge_(int&);
+extern int pychge_(int&);
 /// Purely virtual method to call at the end of the run
 void pystop_() { CG_INFO("pythia6:pystop") << "End of run"; }
 }
@@ -60,7 +60,7 @@ namespace pythia6 {
 
   double pyp(int id, int qty) { return pyp_(id, qty); }
 
-  double pychge(int pdgid) { return pychge_(pdgid); }
+  int pychge(int pdgid) { return pychge_(pdgid); }
 
   std::string pyname(int pdgid) {
     // maximal number of characters to fetch for the particle's name
@@ -124,7 +124,7 @@ namespace pythia6 {
     prop.mass = pymass(pdg_id);
     prop.width = -1.;  //pmas( pdg_id, 2 ),
     if (const auto ch = pychge(pdg_id); std::fabs(ch) > 0)
-      prop.charges = {-std::abs(int(ch * 3.)), +std::abs(int(ch * 3.))};
+      prop.charges = {ch, -ch};
     prop.fermion = false;
     cepgen::PDG::get().define(prop);
   }

--- a/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
@@ -95,8 +95,8 @@ namespace cepgen {
 #endif
       const auto& kin = runParameters().kinematics();
 
-      pythia_->settings.parm("Beams:idA", (long)kin.incomingBeams().positive().pdgId());
-      pythia_->settings.parm("Beams:idB", (long)kin.incomingBeams().negative().pdgId());
+      pythia_->settings.parm("Beams:idA", (long)kin.incomingBeams().positive().integerPdgId());
+      pythia_->settings.parm("Beams:idB", (long)kin.incomingBeams().negative().integerPdgId());
       // specify we will be using a LHA input
       pythia_->settings.mode("Beams:frameType", 5);
       pythia_->settings.parm("Beams:eCM", kin.incomingBeams().sqrtS());

--- a/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/Pythia8Hadroniser.cpp
@@ -235,7 +235,8 @@ namespace cepgen {
         prop.colours = py_part.col();  // colour factor
         prop.mass = py_part.m0();
         prop.width = py_part.mWidth();
-        prop.charge = py_part.charge();  // charge
+        if (const auto ch = int(py_part.charge() * 3.); std::abs(ch) > 0)
+          prop.charges = {ch, -ch};
         prop.fermion = py_part.isLepton();
         PDG::get().define(prop);
       }

--- a/CepGenAddOns/Pythia8Wrapper/PythiaEventInterface.cpp
+++ b/CepGenAddOns/Pythia8Wrapper/PythiaEventInterface.cpp
@@ -34,9 +34,9 @@ namespace Pythia8 {
     inel1_ = !params_->kinematics().incomingBeams().positive().elastic();
     inel2_ = !params_->kinematics().incomingBeams().negative().elastic();
 
-    setBeamA((short)params_->kinematics().incomingBeams().positive().pdgId(),
+    setBeamA((short)params_->kinematics().incomingBeams().positive().integerPdgId(),
              params_->kinematics().incomingBeams().positive().momentum().pz());
-    setBeamB((short)params_->kinematics().incomingBeams().negative().pdgId(),
+    setBeamB((short)params_->kinematics().incomingBeams().negative().integerPdgId(),
              params_->kinematics().incomingBeams().negative().momentum().pz());
     //addProcess( 0, params_->integration().result, params_->integration().err_result, 100. );
   }

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -63,14 +63,14 @@ public:
                                     {Particle::Parton2, {PDG::photon}},
                                     {Particle::OutgoingBeam1, {PDG::proton}},
                                     {Particle::OutgoingBeam2, {PDG::proton}},
-                                    {Particle::CentralSystem, {pair_.pdgid, pair_.pdgid}}});
+                                    {Particle::CentralSystem, {+(spdgid_t)pair_.pdgid, -(spdgid_t)pair_.pdgid}}});
   }
 
   double computeWeight() override;
 
   void prepareKinematics() override {
     ml2_ = pair_.mass * pair_.mass;
-    charge_factor_ = std::pow(pair_.charge / 3., 2);
+    charge_factor_ = std::pow(pair_.integerCharge() / 3., 2);
     beams_mode_ = kinematics().incomingBeams().mode();
     ep1_ = pA().energy();
     ep2_ = pB().energy();

--- a/CepGenProcesses/PPtoFF.cpp
+++ b/CepGenProcesses/PPtoFF.cpp
@@ -56,10 +56,10 @@ private:
   void prepareFactorisedPhaseSpace() override {
     const auto cs_prop = PDG::get()(psgen_->central().at(0));
     // define central particle properties and couplings with partons
-    if (!cs_prop.fermion || cs_prop.charge == 0.)
+    if (!cs_prop.fermion || cs_prop.charges.empty())
       throw CG_FATAL("PPtoFF:prepare") << "Invalid fermion pair selected: " << cs_prop << ".";
     mf2_ = cs_prop.mass * cs_prop.mass;
-    qf2_ = cs_prop.charge * cs_prop.charge * (1. / 9);
+    qf2_ = std::pow(cs_prop.integerCharge() * (1. / 3), 2);
     const auto generate_coupling = [this, &cs_prop](const pdgid_t& parton_id) -> std::function<double(double)> {
       switch (parton_id) {
         case PDG::gluon: {

--- a/CepGenProcesses/PPtoFF.cpp
+++ b/CepGenProcesses/PPtoFF.cpp
@@ -28,11 +28,13 @@
 
 using namespace cepgen;
 
+auto make_pdgids_pair = [](pdgid_t pair) { return spdgids_t(pair, -pair); };
+
 /// Compute the 2-to-4 matrix element for a CE \f$\gamma\gamma\rightarrow f\bar f\f$ process
 class PPtoFF final : public cepgen::proc::FactorisedProcess {
 public:
   explicit PPtoFF(const ParametersList& params)
-      : cepgen::proc::FactorisedProcess(params, pdgids_t(2, params.get<ParticleProperties>("pair").pdgid)),
+      : cepgen::proc::FactorisedProcess(params, make_pdgids_pair(params.get<ParticleProperties>("pair").pdgid)),
         method_(steerAs<int, Mode>("method")),
         osp_(steer<ParametersList>("offShellParameters")) {
     if (method_ == Mode::offShell && !psgen_->ktFactorised())

--- a/CepGenProcesses/PPtoWW.cpp
+++ b/CepGenProcesses/PPtoWW.cpp
@@ -37,7 +37,7 @@ using namespace std::complex_literals;
 class PPtoWW final : public cepgen::proc::FactorisedProcess {
 public:
   explicit PPtoWW(const ParametersList& params)
-      : FactorisedProcess(params, {PDG::W, PDG::W}),
+      : FactorisedProcess(params, {+(spdgid_t)PDG::W, -(spdgid_t)PDG::W}),
         mW_(PDG::get().mass(PDG::W)),
         mW2_(mW_ * mW_),
         method_(steer<int>("method")),

--- a/test/benchmarks/generator.cc
+++ b/test/benchmarks/generator.cc
@@ -51,8 +51,8 @@ int main(int argc, char* argv[]) {
 
   gen.runParameters().setProcess(cepgen::ProcessFactory::get().build(process));
   auto& kin = gen.runParameters().process().kinematics();
-  kin.incomingBeams().positive().setPdgId(2212);
-  kin.incomingBeams().negative().setPdgId(2212);
+  kin.incomingBeams().positive().setIntegerPdgId(2212);
+  kin.incomingBeams().negative().setIntegerPdgId(2212);
   kin.incomingBeams().setSqrtS(13.e3);
   kin.cuts().central.pt_single.min() = 15.;
   kin.cuts().central.eta_single = {-2.5, 2.5};

--- a/test/physics/mcd_parser.cc
+++ b/test/physics/mcd_parser.cc
@@ -43,6 +43,11 @@ int main(int argc, char* argv[]) {
   CG_TEST_EQUIV(cepgen::PDG::get().mass(12), 0., "electron neutrino mass");
   CG_TEST_EQUIV(cepgen::PDG::get().mass(14), 0., "muon neutrino mass");
   CG_TEST_EQUIV(cepgen::PDG::get().mass(16), 0., "tau neutrino mass");
+  {
+    const auto exp_ele_ch = std::vector<double>{-1., 1.};
+    CG_TEST_EQUAL(cepgen::PDG::get().charges(11), exp_ele_ch, "electron/positron charges");
+  }
+  CG_TEST_EQUAL(cepgen::PDG::get().charges(22), std::vector<double>{}, "photon charge");
 
   CG_TEST_SUMMARY;
 }

--- a/test/physics/mcd_parser.cc
+++ b/test/physics/mcd_parser.cc
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
       .parse();
 
   pdg::MCDFileParser::parse(path);
-  cepgen::PDG::get().dump();
+  CG_DEBUG("main").log([](auto& log) { cepgen::PDG::get().dump(&log.stream()); });
   CG_TEST_SET_PRECISION(1.e-6);
 
   CG_TEST_EQUIV(cepgen::PDG::get().mass(cepgen::PDG::diffractiveProton), 0., "diffractive proton bare mass");
@@ -47,6 +47,8 @@ int main(int argc, char* argv[]) {
     const auto exp_ele_ch = std::vector<double>{-1., 1.};
     CG_TEST_EQUAL(cepgen::PDG::get().charges(11), exp_ele_ch, "electron/positron charges");
   }
+  CG_TEST_EQUAL(cepgen::PDG::get().charge(11), -1, "electron charge");
+  CG_TEST_EQUAL(cepgen::PDG::get().charge(-11), 1, "positron charge");
   CG_TEST_EQUAL(cepgen::PDG::get().charges(22), std::vector<double>{}, "photon charge");
 
   CG_TEST_SUMMARY;

--- a/test/utils/steer_physicsproperties.cc
+++ b/test/utils/steer_physicsproperties.cc
@@ -8,7 +8,7 @@
 
 class TestObject : public cepgen::SteeredObject<TestObject> {
 public:
-  explicit TestObject(const cepgen::ParametersList& params)
+  explicit TestObject(const cepgen::ParametersList& params = cepgen::ParametersList())
       : cepgen::SteeredObject<TestObject>(params),
         particle_props_(steer<cepgen::ParticleProperties>("particleProps")) {}
   const cepgen::ParticleProperties& particleProperties() const { return particle_props_; }
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
   }
   {
     cepgen::initialise();
-    auto object = TestObject(cepgen::ParametersList());
+    TestObject object;
     CG_TEST_EQUAL(
         object.particleProperties(), cepgen::PDG::get()(cepgen::PDG::muon), "Full particle properties object");
   }


### PR DESCRIPTION
This PR introduces the capability to handle process-wise, and behind-the-scene-wise the sign of a PDG id, telling whether we are coping with a particle or its anti-particle.
The current PDG bookkeeping feature consequently allows the mirroring of its electric charge, as unique quantum number.