### PR TITLE
Particles/antiparticles

### DIFF
--- a/CepGen/Event/Particle.cpp
+++ b/CepGen/Event/Particle.cpp
@@ -116,12 +116,14 @@ namespace cepgen {
 
   pdgid_t Particle::pdgId() const { return pdg_id_; }
 
-  Particle& Particle::setPdgId(long pdg) {
+  Particle& Particle::setPdgId(pdgid_t pdg, short ch) { return setIntegerPdgId(pdg * (ch == 0 ? 1 : ch / abs(ch))); }
+
+  Particle& Particle::setIntegerPdgId(long pdg) {
     pdg_id_ = labs(pdg);
     if (PDG::get().has(pdg_id_)) {
       phys_prop_ = PDG::get()(pdg_id_);
-      CG_DEBUG("Particle:setPdgId") << "Particle PDG id set to " << pdg_id_ << ", "
-                                    << "properties set " << phys_prop_ << ".";
+      CG_DEBUG("Particle:setIntegerPdgId") << "Particle PDG id set to " << pdg_id_ << ", "
+                                           << "properties set " << phys_prop_ << ".";
     }
     switch (pdg_id_) {
       case 0:
@@ -139,13 +141,11 @@ namespace cepgen {
     return *this;
   }
 
-  Particle& Particle::setPdgId(pdgid_t pdg, short ch) { return setPdgId(long(pdg * (ch == 0 ? 1 : ch / abs(ch)))); }
-
-  int Particle::integerPdgId() const {
+  long Particle::integerPdgId() const {
     const float ch = phys_prop_.charge / 3.;
     if (ch == 0)
-      return static_cast<int>(pdg_id_);
-    return static_cast<int>(pdg_id_) * charge_sign_ * (ch / fabs(ch));
+      return static_cast<long>(pdg_id_);
+    return static_cast<long>(pdg_id_) * charge_sign_ * (ch / fabs(ch));
   }
 
   std::ostream& operator<<(std::ostream& os, const Particle& part) {

--- a/CepGen/Event/Particle.cpp
+++ b/CepGen/Event/Particle.cpp
@@ -31,7 +31,7 @@ namespace cepgen {
 
   Particle::Particle(const Particle& part)
       : id_(part.id_),
-        charge_sign_(part.charge_sign_),
+        antiparticle_(part.antiparticle_),
         momentum_(part.momentum_),
         helicity_(part.helicity_),
         role_(part.role_),
@@ -53,7 +53,7 @@ namespace cepgen {
     return true;
   }
 
-  float Particle::charge() const { return charge_sign_ * phys_prop_.integerCharge() / 3.; }
+  float Particle::charge() const { return (antiparticle_ ? -1 : +1) * phys_prop_.integerCharge() / 3.; }
 
   Particle& Particle::clearMothers() {
     mothers_.clear();
@@ -119,33 +119,16 @@ namespace cepgen {
   Particle& Particle::setPdgId(pdgid_t pdg, short ch) { return setIntegerPdgId(pdg * (ch == 0 ? 1 : ch / abs(ch))); }
 
   Particle& Particle::setIntegerPdgId(long pdg) {
-    pdg_id_ = labs(pdg);
-    if (PDG::get().has(pdg_id_)) {
+    if (pdg_id_ = labs(pdg); PDG::get().has(pdg_id_)) {
       phys_prop_ = PDG::get()(pdg_id_);
       CG_DEBUG("Particle:setIntegerPdgId") << "Particle PDG id set to " << pdg_id_ << ", "
                                            << "properties set " << phys_prop_ << ".";
     }
-    switch (pdg_id_) {
-      case 0:
-        charge_sign_ = 0.;
-        break;
-      case PDG::electron:
-      case PDG::muon:
-      case PDG::tau:
-        charge_sign_ = -pdg / labs(pdg);
-        break;
-      default:
-        charge_sign_ = pdg / labs(pdg);
-        break;
-    }
+    antiparticle_ = pdg < 0;
     return *this;
   }
 
-  long Particle::integerPdgId() const {
-    if (const auto ch = phys_prop_.integerCharge(); ch != 0)
-      return static_cast<long>(pdg_id_) * charge_sign_ * (ch / std::abs(ch));
-    return static_cast<long>(pdg_id_);
-  }
+  long Particle::integerPdgId() const { return static_cast<long>(pdg_id_) * (antiparticle_ ? -1 : +1); }
 
   std::ostream& operator<<(std::ostream& os, const Particle& part) {
     os << std::resetiosflags(std::ios::showbase) << "Particle[" << part.id_ << "]{role=" << part.role_

--- a/CepGen/Event/Particle.h
+++ b/CepGen/Event/Particle.h
@@ -28,8 +28,7 @@
 #include "CepGen/Utils/Hasher.h"
 
 namespace cepgen {
-  /// A set of integer-type particle identifiers
-  typedef std::set<int> ParticlesIds;
+  typedef std::set<int> ParticlesIds;  ///< A set of integer-type particle identifiers
 
   /// Kinematic information for one particle
   class Particle {
@@ -47,8 +46,7 @@ namespace cepgen {
       Undecayed = 2,            ///< Particle to be decayed externally
       Unfragmented = 3          ///< Particle to be hadronised externally
     };
-    /// Human-readable format for a particle's role in the event
-    friend std::ostream& operator<<(std::ostream& os, const Status&);
+    friend std::ostream& operator<<(std::ostream& os, const Status&);  ///< Human-readable particle's status
     /// Role of the particle in the process
     enum Role {
       UnknownRole = -1,   ///< Undefined role
@@ -61,8 +59,7 @@ namespace cepgen {
       Parton1 = 41,       ///< \f$z>0\f$ beam incoming parton
       Parton2 = 42        ///< \f$z<0\f$ beam incoming parton
     };
-    /// Human-readable format for a particle's role in the event
-    friend std::ostream& operator<<(std::ostream& os, const Role&);
+    friend std::ostream& operator<<(std::ostream& os, const Role&);  ///< Human-readable particle's role in the event
 
     //----- static getters
 
@@ -71,51 +68,39 @@ namespace cepgen {
     /// \param[in] id PDG identifier
     /// \param[in] st Current status
     explicit Particle(Role role = Role::UnknownRole, pdgid_t id = 0, Status st = Status::Undefined);
-    /// Copy constructor
-    Particle(const Particle&);
+    Particle(const Particle&);  ///< Copy constructor
     inline ~Particle() = default;
     Particle& operator=(const Particle&) = default;  ///< Assignment operator
-    /// Comparison operator (from unique identifier)
-    bool operator<(const Particle& rhs) const;
-    /// Comparison operator (from their reference's unique identifier)
-    //bool operator<( Particle *rhs ) const { return ( id < rhs->id ); }
+    bool operator<(const Particle& rhs) const;       ///< Comparison operator (from unique identifier)
 
     // --- general particle properties
 
-    /// Unique identifier (in a Event object context)
-    int id() const { return id_; }
-    //void setId( int id ) { id_ = id; }
+    inline int id() const { return id_; }  ///< Unique identifier (in a Event object context)
     /// Set the particle unique identifier in an event
-    Particle& setId(int id) {
+    inline Particle& setId(int id) {
       id_ = id;
       return *this;
     }
-    /// Electric charge (given as a float number, for the quarks and bound states)
-    float charge() const;
-    /// Set the electric charge sign (+-1 for charged or 0 for neutral particles)
-    Particle& setChargeSign(int sign) {
-      charge_sign_ = sign;
+    float charge() const;  ///< Electric charge (given as a float number, for the quarks and bound states)
+    /// Set whether we are coping with the particle or its antiparticle
+    inline Particle& setAntiparticle(bool anti) {
+      antiparticle_ = anti;
       return *this;
     }
-    /// Role in the considered process
-    Role role() const { return role_; }
+    inline Role role() const { return role_; }  ///< Role in the considered process
     /// Set the particle role in the process
-    Particle& setRole(const Role& role) {
+    inline Particle& setRole(const Role& role) {
       role_ = role;
       return *this;
     }
-    /**
-       * Codes 1-10 correspond to currently existing partons/particles, and larger codes contain partons/particles which no longer exist, or other kinds of event information
-       * \brief Particle status
-       */
-    Status status() const { return (Status)status_; }
+    inline Status status() const { return (Status)status_; }  ///< Particle status
     /// Set the particle decay/stability status
-    Particle& setStatus(Status status) {
+    inline Particle& setStatus(Status status) {
       status_ = (int)status;
       return *this;
     }
     /// Set the particle decay/stability status
-    Particle& setStatus(int status) {
+    inline Particle& setStatus(int status) {
       status_ = status;
       return *this;
     }
@@ -130,105 +115,71 @@ namespace cepgen {
     Particle& setIntegerPdgId(long pdg_id);
     long integerPdgId() const;  ///< Retrieve the integer value of the PDG identifier
 
-    float helicity() const { return helicity_; }  ///< Particle's helicity
+    inline float helicity() const { return helicity_; }  ///< Particle's helicity
     /// Set the helicity of the particle
-    Particle& setHelicity(float heli) {
+    inline Particle& setHelicity(float heli) {
       helicity_ = heli;
       return *this;
     }
 
-    /// Retrieve the momentum object associated with this particle
-    inline Momentum& momentum() { return momentum_; }
+    inline Momentum& momentum() { return momentum_; }  ///< Retrieve the momentum object associated with this particle
     /// Retrieve the momentum object associated with this particle
     inline const Momentum& momentum() const { return momentum_; }
     /// Associate a momentum object to this particle
-    Particle& setMomentum(const Momentum& mom, bool offshell = false);
-    /**
-       * \brief Set the 3- or 4-momentum associated to the particle
-       * \param[in] px Momentum along the \f$x\f$-axis, in GeV/c
-       * \param[in] py Momentum along the \f$y\f$-axis, in GeV/c
-       * \param[in] pz Momentum along the \f$z\f$-axis, in GeV/c
-       * \param[in] e Energy, in GeV
-       */
+    /// \param[in] offshell allow the 4-momentum mass to compensate for E-p balance?
+    Particle& setMomentum(const Momentum&, bool offshell = false);
+    /// Set the 3- or 4-momentum associated to the particle
+    /// \param[in] px Momentum along the \f$x\f$-axis, in GeV/c
+    /// \param[in] py Momentum along the \f$y\f$-axis, in GeV/c
+    /// \param[in] pz Momentum along the \f$z\f$-axis, in GeV/c
+    /// \param[in] e Energy, in GeV
     Particle& setMomentum(double px, double py, double pz, double e = -1.);
     /// Set the 4-momentum associated to the particle
     /// \param[in] p 4-momentum
     inline Particle& setMomentum(double p[4]) { return setMomentum(p[0], p[1], p[2], p[3]); }
-    /// Is this particle a valid particle which can be used for kinematic computations?
-    bool valid();
+    bool valid();  ///< Is this particle a valid particle which can be used for kinematic computations?
 
     // --- particle relations
 
-    /// Is this particle a primary particle?
-    inline bool primary() const { return mothers_.empty(); }
-    /// Clear the particle parentage
-    Particle& clearMothers();
-    /// Set the mother particle
-    /// \param[in] part A Particle object containing all the information on the mother particle
-    Particle& addMother(Particle& part);
-    /// Get the unique identifier to the mother particle from which this particle arises
-    /// \return An integer representing the unique identifier to the mother of this particle in the event
-    inline ParticlesIds mothers() const { return mothers_; }
-    /// Remove the decay products linking
-    Particle& clearDaughters();
-    /**
-       * \brief Add a decay product
-       * \param[in] part The Particle object in which this particle will disintegrate or convert
-       * \return A boolean stating if the particle has been added to the daughters list or if it was already present before
-       */
-    Particle& addDaughter(Particle& part);
-    /// Gets the number of daughter particles
-    inline size_t numDaughters() const { return daughters_.size(); };
-    /// Get an identifiers list all daughter particles
-    /// \return An integer vector containing all the daughters' unique identifier in the event
-    inline ParticlesIds daughters() const { return daughters_; }
+    inline bool primary() const { return mothers_.empty(); }           ///< Is this particle a primary particle?
+    Particle& clearMothers();                                          ///< Clear the particle parentage
+    Particle& addMother(Particle& part);                               ///< Set the mother particle
+    inline ParticlesIds mothers() const { return mothers_; }           ///< Identifier to the mother particles
+    Particle& clearDaughters();                                        ///< Remove the decay products linking
+    Particle& addDaughter(Particle& part);                             ///< Add a decay product
+    inline size_t numDaughters() const { return daughters_.size(); };  ///< Number of daughter particles
+    inline ParticlesIds daughters() const { return daughters_; }       ///< Identifiers list of all daughter particles
 
     // --- global particle information extraction
 
-    /// Dump all the information on this particle into the standard output stream
-    friend std::ostream& operator<<(std::ostream&, const Particle&);
+    friend std::ostream& operator<<(std::ostream&, const Particle&);  ///< Human-readable dump of particle information
 
   protected:
-    /// Unique identifier in an event
-    int id_{-1};
-    /// Electric charge (+-1 or 0)
-    short charge_sign_{1};
-    /// Momentum properties handler
-    Momentum momentum_;
-    /// Helicity
-    float helicity_{0.};
-    /// Role in the process
-    Role role_{UnknownRole};
-    /// Decay/stability status
-    int status_{(int)Status::Undefined};
-    /// List of mother particles
-    ParticlesIds mothers_{};
-    /// List of daughter particles
-    ParticlesIds daughters_{};
-    /// PDG id
-    pdgid_t pdg_id_{(pdgid_t)0};
-    /// Collection of standard, bare-level physical properties
-    ParticleProperties phys_prop_;
+    int id_{-1};                          ///< Unique identifier in an event
+    bool antiparticle_{false};            ///< Are we dealing with the particle or antiparticle?
+    Momentum momentum_;                   ///< Momentum properties handler
+    float helicity_{0.};                  ///< Helicity
+    Role role_{UnknownRole};              ///< Role in the process
+    int status_{(int)Status::Undefined};  ///< Decay/stability status
+    ParticlesIds mothers_{};              ///< List of mother particles
+    ParticlesIds daughters_{};            ///< List of daughter particles
+    pdgid_t pdg_id_{(pdgid_t)0};          ///< PDG id
+    ParticleProperties phys_prop_;        ///< Collection of standard, bare-level physical properties
   };
 
   // --- particle containers
 
-  /// Reference to a Particle object
-  typedef std::reference_wrapper<Particle> ParticleRef;
-  /// List of Particle objects
-  typedef std::vector<Particle> Particles;
-  /// List of references to Particle objects
-  typedef std::vector<ParticleRef> ParticlesRefs;
-  /// List of particles' roles
-  typedef std::vector<Particle::Role> ParticleRoles;
+  typedef std::reference_wrapper<Particle> ParticleRef;  ///< Reference to a Particle object
+  typedef std::vector<Particle> Particles;               ///< List of Particle objects
+  typedef std::vector<ParticleRef> ParticlesRefs;        ///< List of references to Particle objects
+  typedef std::vector<Particle::Role> ParticleRoles;     ///< List of particles' roles
+
   /// Map between a particle's role and its associated Particle object
   class ParticlesMap : public std::unordered_map<Particle::Role, Particles, utils::EnumHash<Particle::Role> > {
   public:
     ParticlesMap() = default;
-    /// Copy constructor
-    ParticlesMap(const ParticlesMap&);
-    /// Assignment operator
-    ParticlesMap& operator=(const ParticlesMap&);
+    ParticlesMap(const ParticlesMap&);             ///< Copy constructor
+    ParticlesMap& operator=(const ParticlesMap&);  ///, Assignment operator
   };
 }  // namespace cepgen
 

--- a/CepGen/Event/Particle.h
+++ b/CepGen/Event/Particle.h
@@ -124,20 +124,19 @@ namespace cepgen {
     /// \param[in] pdg PDG identifier
     /// \param[in] ch Electric charge (0, 1, or -1)
     Particle& setPdgId(pdgid_t pdg, short ch = 0);
+    pdgid_t pdgId() const;  ///< Retrieve the objectified PDG identifier
     /// Set the PDG identifier (along with the particle's electric charge)
     /// \param[in] pdg_id PDG identifier (incl. electric charge in e)
-    Particle& setPdgId(long pdg_id);
-    /// Retrieve the objectified PDG identifier
-    pdgid_t pdgId() const;
-    /// Retrieve the integer value of the PDG identifier
-    int integerPdgId() const;
-    /// Particle's helicity
-    float helicity() const { return helicity_; }
+    Particle& setIntegerPdgId(long pdg_id);
+    long integerPdgId() const;  ///< Retrieve the integer value of the PDG identifier
+
+    float helicity() const { return helicity_; }  ///< Particle's helicity
     /// Set the helicity of the particle
     Particle& setHelicity(float heli) {
       helicity_ = heli;
       return *this;
     }
+
     /// Retrieve the momentum object associated with this particle
     inline Momentum& momentum() { return momentum_; }
     /// Retrieve the momentum object associated with this particle

--- a/CepGen/Process/PhaseSpaceGenerator2to4.cpp
+++ b/CepGen/Process/PhaseSpaceGenerator2to4.cpp
@@ -197,7 +197,7 @@ namespace cepgen {
                                     << ", x2 = " << x2 << ", p = " << proc_->q2().p() << ".";
 
       if (randomise_charge_) {  // randomise the charge of outgoing system
-        const short sign = proc_->randomGenerator().uniformInt(0, 1) == 1;
+        const auto sign = proc_->randomGenerator().uniformInt(0, 1) == 1;
         proc_->event()[Particle::CentralSystem][0].get().setAntiparticle(sign);
         proc_->event()[Particle::CentralSystem][1].get().setAntiparticle(!sign);
       }

--- a/CepGen/Process/PhaseSpaceGenerator2to4.cpp
+++ b/CepGen/Process/PhaseSpaceGenerator2to4.cpp
@@ -197,9 +197,9 @@ namespace cepgen {
                                     << ", x2 = " << x2 << ", p = " << proc_->q2().p() << ".";
 
       if (randomise_charge_) {  // randomise the charge of outgoing system
-        const short sign = proc_->randomGenerator().uniformInt(0, 1) == 1 ? 1 : -1;
-        proc_->event()[Particle::CentralSystem][0].get().setChargeSign(+sign);
-        proc_->event()[Particle::CentralSystem][1].get().setChargeSign(-sign);
+        const short sign = proc_->randomGenerator().uniformInt(0, 1) == 1;
+        proc_->event()[Particle::CentralSystem][0].get().setAntiparticle(sign);
+        proc_->event()[Particle::CentralSystem][1].get().setAntiparticle(!sign);
       }
       proc_->event()[Particle::CentralSystem][0].get().setStatus(Particle::Status::FinalState);
       proc_->event()[Particle::CentralSystem][1].get().setStatus(Particle::Status::FinalState);

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -167,9 +167,9 @@ public:
                                                                      : Particle::Status::Unfragmented);
 
     // central system
-    const short ransign = rnd_gen_->uniformInt(0, 1) == 1 ? 1 : -1;
-    event()[Particle::CentralSystem][0].get().setChargeSign(+ransign).setStatus(Particle::Status::FinalState);
-    event()[Particle::CentralSystem][1].get().setChargeSign(-ransign).setStatus(Particle::Status::FinalState);
+    const short ransign = rnd_gen_->uniformInt(0, 1) == 1;
+    event()[Particle::CentralSystem][0].get().setAntiparticle(ransign).setStatus(Particle::Status::FinalState);
+    event()[Particle::CentralSystem][1].get().setAntiparticle(!ransign).setStatus(Particle::Status::FinalState);
   }
 
   static ParametersDescription description() {

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -51,8 +51,12 @@ using namespace cepgen;
 class LPAIR final : public cepgen::proc::Process {
 public:
   explicit LPAIR(const ParametersList& params)
-      : proc::Process(params), pair_(steer<ParticleProperties>("pair")), symmetrise_(steer<bool>("symmetrise")) {}
-  LPAIR(const LPAIR& oth) : proc::Process(oth), pair_(oth.pair_), symmetrise_(oth.symmetrise_) {}
+      : proc::Process(params),
+        pair_(steer<ParticleProperties>("pair")),
+        symmetrise_(steer<bool>("symmetrise")),
+        randomise_charge_(steer<bool>("randomiseCharge")) {}
+  LPAIR(const LPAIR& oth)
+      : proc::Process(oth), pair_(oth.pair_), symmetrise_(oth.symmetrise_), randomise_charge_(oth.randomise_charge_) {}
 
   proc::ProcessPtr clone() const override { return proc::ProcessPtr(new LPAIR(*this)); }
 
@@ -167,9 +171,13 @@ public:
                                                                      : Particle::Status::Unfragmented);
 
     // central system
-    const short ransign = rnd_gen_->uniformInt(0, 1) == 1;
-    event()[Particle::CentralSystem][0].get().setAntiparticle(ransign).setStatus(Particle::Status::FinalState);
-    event()[Particle::CentralSystem][1].get().setAntiparticle(!ransign).setStatus(Particle::Status::FinalState);
+    const auto ransign = rnd_gen_->uniformInt(0, 1) == 1;
+    if (randomise_charge_) {  // randomise the charge of outgoing system
+      event()[Particle::CentralSystem][0].get().setAntiparticle(ransign);
+      event()[Particle::CentralSystem][1].get().setAntiparticle(!ransign);
+    }
+    event()[Particle::CentralSystem][0].get().setStatus(Particle::Status::FinalState);
+    event()[Particle::CentralSystem][1].get().setStatus(Particle::Status::FinalState);
   }
 
   static ParametersDescription description() {
@@ -178,6 +186,7 @@ public:
     desc.add<int>("nopt", 0).setDescription("Optimised mode? (inherited from LPAIR, by default disabled = 0)");
     desc.addAs<int, pdgid_t>("pair", PDG::muon).setDescription("Lepton pair considered");
     desc.add<bool>("symmetrise", false).setDescription("Symmetrise along z the central system?");
+    desc.add<bool>("randomiseCharge", true).setDescription("randomise the charges of the two central fermions?");
     return desc;
   }
 
@@ -254,6 +263,7 @@ private:
 
   const ParticleProperties pair_;
   const bool symmetrise_;
+  const bool randomise_charge_;
 
   ///////////////////////////////////////////////////////////////////
   // variables computed at phase space definition


### PR DESCRIPTION
Replaced `cepgen::Particle` object's charge sign attribute by a "particle" or "antiparticle" boolean.
This only influences the charge as single quantum number taken care of in this container.