### PR TITLE
Beam-level form factors

### DIFF
--- a/Cards/lpair_ep_cfg.py
+++ b/Cards/lpair_ep_cfg.py
@@ -1,0 +1,46 @@
+import Config.Core as cepgen
+from Config.PDG_cfi import PDG
+from Config.timer_cfi import timer # enable timing framework
+from Config.generator_cfi import generator as _gen
+from FormFactors.standardDipole_cfi import standardDipole
+from FormFactors.pointLikeFermion_cfi import pointLikeFermion
+#from OutputModules.rootTree_cfi import rootTree # dump everything into a flat tree
+
+
+process = cepgen.Module('lpair',
+    processParameters = cepgen.Parameters(
+        mode = cepgen.ProcessMode.ElasticElastic,
+        pair = PDG.muon,
+    ),
+    inKinematics = cepgen.Parameters(
+        pdgIds = (2212, 11),
+        formFactors = [standardDipole, pointLikeFermion],
+        pz = (7000., 50.),
+    ),
+    outKinematics = cepgen.Parameters(
+        pt = (2.5,),
+    )
+)
+
+# events generation parameters
+generator = _gen.clone(
+    numEvents = 10000,
+    printEvery = 2500,
+)
+
+text = cepgen.Module('text', # histogramming/ASCII output capability
+    histVariables={
+        'm(4)': cepgen.Parameters(xrange=(0., 25.), nbins=20, log=False),
+        'pt(7):pt(8)': cepgen.Parameters(xrange=(0., 5.), yrange=(0., 5.), log=True)
+    }
+)
+#lhef = cepgen.Module('lhef', filename='test.lhe')
+#hepmc = cepgen.Module('hepmc', filename='test.hepmc')
+dump = cepgen.Module('dump', printEvery = generator.printEvery)
+output = cepgen.Sequence(
+    #rootTree,
+    text,
+    #lhef,
+    #hepmc,
+    dump,
+)

--- a/Cards/lpair_pbpb_cfg.py
+++ b/Cards/lpair_pbpb_cfg.py
@@ -2,6 +2,7 @@ import Config.Core as cepgen
 from Config.PDG_cfi import PDG
 from Config.timer_cfi import timer # enable timing framework
 from Config.generator_cfi import generator as _gen
+from FormFactors.heavyIonDipole_cfi import heavyIonDipole
 from OutputModules.dump_cfi import dump as _dump_output # periodic event printout
 from OutputModules.text_cfi import text as _text_output # ASCII histograms
 #from OutputModules.rootTree_cfi import rootTree # dump everything into a flat tree
@@ -15,6 +16,7 @@ process = cepgen.Module('lpair',
     inKinematics = cepgen.Parameters(
         heavyIon1 = (208, 82),
         heavyIon2 = (208, 82),
+        formFactors = [heavyIonDipole, heavyIonDipole],
         pz = (2562.2, 2562.2),
     ),
     outKinematics = cepgen.Parameters(

--- a/CepGen/Core/ParametersList.cpp
+++ b/CepGen/Core/ParametersList.cpp
@@ -271,8 +271,18 @@ namespace cepgen {
     return *this;
   }
 
-  std::string ParametersList::print() const {
+  std::string ParametersList::print(bool compact) const {
     std::ostringstream os;
+    if (compact) {
+      os << utils::colourise(getNameString(), utils::Colour::none, utils::Modifier::underline);
+      if (const auto& keys_list = keys(false); !keys_list.empty()) {
+        std::string sep = "{";
+        for (const auto& key : keys_list)
+          os << sep << key << "=" << getString(key), sep = ", ";
+        os << "}";
+      }
+      return os.str();
+    }
     print(os);
     return os.str();
   }

--- a/CepGen/Core/ParametersList.cpp
+++ b/CepGen/Core/ParametersList.cpp
@@ -395,38 +395,8 @@ namespace cepgen {
 
   IMPL_TYPE_ALL(ParametersList, param_values_);
   IMPL_TYPE_ALL(bool, bool_values_);
-
-  IMPL_TYPE_SET(int, int_values_);
-  template <>
-  int ParametersList::get<int>(const std::string& key, const int& def) const {
-    if (has<int>(key))
-      return int_values_.at(key);
-    if (has<unsigned long long>(key)) {
-      const auto ulong_val = ulong_values_.at(key);
-      if (ulong_val >= std::numeric_limits<int>::max())
-        CG_WARNING("ParametersList:get")
-            << "Trying to retrieve a (too) long unsigned integer with an integer getter. Please fix your code.";
-      return (int)ulong_val;
-    }
-    return def;
-  }
-
-  IMPL_TYPE_SET(unsigned long long, ulong_values_);
-  template <>
-  unsigned long long ParametersList::get<unsigned long long>(const std::string& key,
-                                                             const unsigned long long& def) const {
-    if (has<unsigned long long>(key))
-      return ulong_values_.at(key);
-    if (has<int>(key)) {
-      const auto& int_val = int_values_.at(key);
-      if (int_val < 0)
-        CG_WARNING("ParametersList:get")
-            << "Trying to retrieve a negative-value integer with an unsigned long getter. Please fix your code.";
-      return int_val;
-    }
-    return def;
-  }
-
+  IMPL_TYPE_ALL(int, int_values_);
+  IMPL_TYPE_ALL(unsigned long long, ulong_values_);
   IMPL_TYPE_ALL(double, dbl_values_);
   IMPL_TYPE_ALL(std::string, str_values_);
   IMPL_TYPE_ALL(std::vector<int>, vec_int_values_);

--- a/CepGen/Core/ParametersList.cpp
+++ b/CepGen/Core/ParametersList.cpp
@@ -212,6 +212,8 @@ namespace cepgen {
           set<int>(key, std::stoi(value));
         else if (utils::isFloat(value))
           set<double>(key, std::stod(value));
+        else if (value[0] == value[value.size() - 1] && (value[0] == '\'' || value[0] == '"'))  // string parameter
+          set(key, value.substr(1, value.size() - 2));
         else {
           const auto value_lc = utils::toLower(value);
           if (value_lc == "off" || value_lc == "no" || value_lc == "false")

--- a/CepGen/Core/ParametersList.h
+++ b/CepGen/Core/ParametersList.h
@@ -157,7 +157,7 @@ namespace cepgen {
     friend std::ostream& operator<<(std::ostream&,
                                     const ParametersList&);  ///< Human-readable version of a parameters container
     const ParametersList& print(std::ostream&) const;        ///< Debugging-like printout of a parameters container
-    std::string print() const;                               ///< Normal printout of a parameters container
+    std::string print(bool compact = false) const;           ///< Normal printout of a parameters container
 
   private:
     std::map<std::string, ParametersList> param_values_;

--- a/CepGen/Core/RunParameters.cpp
+++ b/CepGen/Core/RunParameters.cpp
@@ -166,10 +166,10 @@ namespace cepgen {
       for (const auto& key : proc_params.keys(false)) {
         if (key == "kinematics" || key == "partonFluxes" || key == "ktFluxes")  // these are shown below
           continue;
-        if (proc_params.has<ParametersList>(key))
-          os << std::setw(wt) << "" << key << ": " << proc_params.get<ParametersList>(key) << "\n";
-        else
-          os << std::setw(wt) << "" << key << ": " << proc_params.getString(key) << "\n";
+        os << std::setw(wt) << "" << key << ": "
+           << (proc_params.has<ParametersList>(key) ? proc_params.get<ParametersList>(key).print(true)
+                                                    : proc_params.getString(key))
+           << "\n";
       }
     }
     if (!param.evt_modifiers_.empty() || !param.evt_exporters_.empty() || !param.taming_functions_.empty())
@@ -200,7 +200,8 @@ namespace cepgen {
       os << std::setw(wt) << "" << key << ": " << param.integrator_.getString(key) << "\n";
     os << std::setw(wt) << "Event generation? " << utils::yesno(param.generation_.enabled()) << "\n"
        << std::setw(wt) << "Number of events to generate" << utils::boldify(param.generation_.maxGen()) << "\n"
-       << std::setw(wt) << "Generator worker" << param.generation_.parameters().get<ParametersList>("worker") << "\n";
+       << std::setw(wt) << "Generator worker"
+       << param.generation_.parameters().get<ParametersList>("worker").print(true) << "\n";
     if (param.generation_.numThreads() > 1)
       os << std::setw(wt) << "Number of threads" << param.generation_.numThreads() << "\n";
     os << std::setw(wt) << "Number of points to try per bin" << param.generation_.numPoints() << "\n"
@@ -216,7 +217,7 @@ namespace cepgen {
       os << std::setw(wt) << "Structure functions"
          << utils::boldify(
                 StructureFunctionsFactory::get().describeParameters(beams.structureFunctions()).description())
-         << ": " << beams.structureFunctions() << "\n";
+         << " / " << beams.structureFunctions().print(true) << "\n";
     os << "\n"
        << std::setfill('-') << std::setw(wb + 6) << utils::boldify(" Incoming partons ") << std::setfill(' ') << "\n\n";
     const auto& cuts = kin.cuts();

--- a/CepGen/Core/RunParameters.cpp
+++ b/CepGen/Core/RunParameters.cpp
@@ -211,10 +211,7 @@ namespace cepgen {
        << std::setfill('_') << std::setw(wb + 3) << "_/¯ EVENTS KINEMATICS ¯\\_" << std::setfill(' ') << "\n\n"
        << std::setw(wt) << "Incoming particles" << beams.positive() << ",\n"
        << std::setw(wt) << "" << beams.negative() << "\n"
-       << std::setw(wt) << "C.m. energy (GeV)" << utils::format("%g", beams.sqrtS()) << "\n"
-       << std::setw(wt) << "Form factors"
-       << utils::boldify(FormFactorsFactory::get().describeParameters(beams.formFactors()).description()) << ": "
-       << beams.formFactors() << "\n";
+       << std::setw(wt) << "C.m. energy (GeV)" << utils::format("%g", beams.sqrtS()) << "\n";
     if (beams.mode() != mode::Kinematics::ElasticElastic)
       os << std::setw(wt) << "Structure functions"
          << utils::boldify(

--- a/CepGen/Core/RunParameters.cpp
+++ b/CepGen/Core/RunParameters.cpp
@@ -217,7 +217,8 @@ namespace cepgen {
       os << std::setw(wt) << "Structure functions"
          << utils::boldify(
                 StructureFunctionsFactory::get().describeParameters(beams.structureFunctions()).description())
-         << " / " << beams.structureFunctions().print(true) << "\n";
+         << "\n"
+         << std::setw(wt) << "" << beams.structureFunctions().print(true) << "\n ";
     os << "\n"
        << std::setfill('-') << std::setw(wb + 6) << utils::boldify(" Incoming partons ") << std::setfill(' ') << "\n\n";
     const auto& cuts = kin.cuts();

--- a/CepGen/FormFactors/Parameterisation.cpp
+++ b/CepGen/FormFactors/Parameterisation.cpp
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2023  Laurent Forthomme
+ *  Copyright (C) 2013-2024  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ namespace cepgen {
     const FormFactors& Parameterisation::operator()(double q2) {
       if (q2 < 0.)
         ff_ = FormFactors{};
-      else {
+      else if (q2 != q2_) {
         q2_ = q2;
         eval();
       }

--- a/CepGen/Physics/Beam.cpp
+++ b/CepGen/Physics/Beam.cpp
@@ -29,6 +29,7 @@ namespace cepgen {
       : SteeredObject(params),
         pdg_id_(steerAs<int, pdgid_t>("pdgId")),
         momentum_(Momentum::fromPxPyPzM(0., 0., steer<double>("pz"), PDG::get().mass(pdg_id_))),
+        formfac_(steer<ParametersList>("formFactors").set<pdgid_t>("pdgId", std::abs(pdg_id_))),
         flux_info_(steer<ParametersList>("partonFlux")),
         elastic_(steer<bool>("elastic")) {}
 
@@ -46,8 +47,15 @@ namespace cepgen {
     else
       os << (PDG::Id)beam.pdg_id_;
     os << " (" << beam.momentum_.pz() << " GeV/c) " << (beam.elastic_ ? "elastic" : "inelastic");
-    if (!beam.flux_info_.name<std::string>().empty())
-      os << " [part.flux: " << beam.flux_info_ << "]";
+    const auto &formfac_name = beam.formfac_.name<std::string>(), &part_flux_name = beam.flux_info_.name<std::string>();
+    if (!formfac_name.empty() || !part_flux_name.empty()) {
+      os << " [" << formfac_name;
+      if (!formfac_name.empty() && !part_flux_name.empty())
+        os << ", ";
+      if (!part_flux_name.empty())
+        os << beam.flux_info_;
+      os << "]";
+    }
     return os;
   }
 }  // namespace cepgen

--- a/CepGen/Physics/Beam.cpp
+++ b/CepGen/Physics/Beam.cpp
@@ -36,7 +36,6 @@ namespace cepgen {
     auto desc = ParametersDescription();
     desc.addAs<int, pdgid_t>("pdgId", PDG::proton);
     desc.add<double>("pz", 0.);
-    desc.add<ParametersDescription>("partonFlux", ParametersDescription());
     return desc;
   }
 

--- a/CepGen/Physics/Beam.cpp
+++ b/CepGen/Physics/Beam.cpp
@@ -28,10 +28,9 @@ namespace cepgen {
   Beam::Beam(const ParametersList& params)
       : SteeredObject(params),
         pdg_id_(steerAs<int, pdgid_t>("pdgId")),
-        momentum_(Momentum::fromPxPyPzM(0., 0., steer<double>("pz"), PDG::get().mass(pdg_id_))),
-        formfac_(steer<ParametersList>("formFactors").set<pdgid_t>("pdgId", std::abs(pdg_id_))),
-        flux_info_(steer<ParametersList>("partonFlux")),
-        elastic_(steer<bool>("elastic")) {}
+        momentum_(Momentum::fromPxPyPzM(0., 0., steer<double>("pz"), PDG::get().mass(pdg_id_))) {
+    (*this).add("formFactors", formfac_).add("partonFlux", flux_info_).add("elastic", elastic_);
+  }
 
   ParametersDescription Beam::description() {
     auto desc = ParametersDescription();
@@ -49,7 +48,7 @@ namespace cepgen {
     os << " (" << beam.momentum_.pz() << " GeV/c) " << (beam.elastic_ ? "elastic" : "inelastic");
     const auto &formfac_name = beam.formfac_.name<std::string>(), &part_flux_name = beam.flux_info_.name<std::string>();
     if (!formfac_name.empty() || !part_flux_name.empty()) {
-      os << " [" << formfac_name;
+      os << " [" << beam.formfac_;
       if (!formfac_name.empty() && !part_flux_name.empty())
         os << ", ";
       if (!part_flux_name.empty())

--- a/CepGen/Physics/Beam.cpp
+++ b/CepGen/Physics/Beam.cpp
@@ -41,20 +41,12 @@ namespace cepgen {
   }
 
   std::ostream& operator<<(std::ostream& os, const Beam& beam) {
-    if (HeavyIon::isHI(beam.pdg_id_))
-      os << HeavyIon::fromPdgId(beam.pdg_id_);
-    else
-      os << (PDG::Id)beam.pdg_id_;
-    os << " (" << beam.momentum_.pz() << " GeV/c) " << (beam.elastic_ ? "elastic" : "inelastic");
-    const auto &formfac_name = beam.formfac_.name<std::string>(), &part_flux_name = beam.flux_info_.name<std::string>();
-    if (!formfac_name.empty() || !part_flux_name.empty()) {
-      os << " [" << beam.formfac_;
-      if (!formfac_name.empty() && !part_flux_name.empty())
-        os << ", ";
-      if (!part_flux_name.empty())
-        os << beam.flux_info_;
-      os << "]";
-    }
+    os << (PDG::Id)beam.pdg_id_ << " (" << beam.momentum_.pz() << " GeV/c) "
+       << (beam.elastic_ ? "elastic" : "inelastic");
+    if (const auto& part_flux_name = beam.flux_info_.name<std::string>(); !part_flux_name.empty())
+      os << " [parton flux: " << beam.flux_info_.print(true) << "]";
+    else if (const auto& formfac_name = beam.formfac_.name<std::string>(); !formfac_name.empty())
+      os << " [form factors: " << beam.formfac_.print(true) << "]";
     return os;
   }
 }  // namespace cepgen

--- a/CepGen/Physics/Beam.h
+++ b/CepGen/Physics/Beam.h
@@ -58,11 +58,13 @@ namespace cepgen {
       return *this;
     }
 
+    inline const ParametersList& formFactors() const { return formfac_; }             ///< Form factors parameters
     inline const ParametersList& partonFluxParameters() const { return flux_info_; }  ///< Parton flux modelling
 
   private:
     spdgid_t pdg_id_{0};        ///< PDG identifier for the beam
     Momentum momentum_;         ///< Incoming particle momentum
+    ParametersList formfac_;    ///< Form factors modelling parameters
     ParametersList flux_info_;  ///< Incoming parton flux parameters
     bool elastic_{true};        ///< Elastic parton emission?
   };

--- a/CepGen/Physics/IncomingBeams.cpp
+++ b/CepGen/Physics/IncomingBeams.cpp
@@ -158,9 +158,11 @@ namespace cepgen {
                           mode == mode::Kinematics::ElasticElastic || mode == mode::Kinematics::InelasticElastic);
     } else {
       const auto set_beam_elasticity = [](ParametersList& plist_beam) {
-        if (const auto& parton_flux_mod = plist_beam.get<ParametersList>("partonFlux"); !parton_flux_mod.empty())
+        if (const auto& parton_flux_mod = plist_beam.get<ParametersList>("partonFlux");
+            !parton_flux_mod.name<std::string>().empty())
           plist_beam.set<bool>("elastic", PartonFluxFactory::get().elastic(parton_flux_mod));
-        else if (const auto& formfac_mod = plist_beam.get<ParametersList>("formFactors"); !formfac_mod.empty())
+        else if (const auto& formfac_mod = plist_beam.get<ParametersList>("formFactors");
+                 !formfac_mod.name<std::string>().empty())
           plist_beam.set<bool>("elastic", !FormFactorsFactory::get().build(formfac_mod)->fragmenting());
         else {
           CG_WARNING("IncomingBeams") << "Neither kinematics mod, parton flux modelling, or form factors modelling "

--- a/CepGen/Physics/IncomingBeams.h
+++ b/CepGen/Physics/IncomingBeams.h
@@ -40,7 +40,6 @@ namespace cepgen {
     inline const Beam& negative() const { return neg_beam_; }  ///< Reference to the negative-z beam information
     inline Beam& negative() { return neg_beam_; }              ///< Reference to the negative-z beam information
 
-    inline const ParametersList& formFactors() const { return formfac_; }        ///< Form factors parameters
     inline const ParametersList& structureFunctions() const { return strfun_; }  ///< Structure functions parameters
     void setStructureFunctions(int, int);  ///< Set the integer-type of structure functions evaluator to build
 
@@ -49,7 +48,6 @@ namespace cepgen {
     double sqrtS() const;   ///< Incoming beams centre of mass energy (in GeV)
 
   private:
-    ParametersList formfac_;
     ParametersList strfun_;
     Beam pos_beam_{ParametersList()};
     Beam neg_beam_{ParametersList()};

--- a/CepGen/Physics/Kinematics.cpp
+++ b/CepGen/Physics/Kinematics.cpp
@@ -24,8 +24,6 @@ namespace cepgen {
   Kinematics::Kinematics(const ParametersList& params) : SteeredObject(params) {}
 
   void Kinematics::setParameters(const ParametersList& params) {
-    if (params.empty())
-      return;
     SteeredObject::setParameters(params);
     CG_DEBUG("Kinematics") << "Building a Kinematics parameters container "
                            << "with the following parameters:\n\t" << params_ << ".";

--- a/CepGen/Physics/PDG.cpp
+++ b/CepGen/Physics/PDG.cpp
@@ -24,7 +24,11 @@
 #include "CepGen/Utils/String.h"
 
 namespace cepgen {
-  std::ostream& operator<<(std::ostream& os, const PDG::Id& pdg) { return os << PDG::get().name(pdg); }
+  std::ostream& operator<<(std::ostream& os, const PDG::Id& pdg) {
+    if (HeavyIon::isHI(pdg))
+      return os << HeavyIon::fromPdgId(pdg);
+    return os << PDG::get().name(pdg);
+  }
 
   PDG::PDG() {
     // PDG id, name, description, colour, mass, width, charge, is fermion

--- a/CepGen/Process/FactorisedProcess.cpp
+++ b/CepGen/Process/FactorisedProcess.cpp
@@ -18,6 +18,7 @@
 
 #include "CepGen/Core/Exception.h"
 #include "CepGen/Event/Event.h"
+#include "CepGen/Modules/PartonFluxFactory.h"
 #include "CepGen/Modules/PhaseSpaceGeneratorFactory.h"
 #include "CepGen/Physics/Beam.h"
 #include "CepGen/Physics/PDG.h"
@@ -112,6 +113,14 @@ namespace cepgen {
     ParametersDescription FactorisedProcess::description() {
       auto desc = Process::description();
       desc.setDescription("Unnamed factorised process");
+      desc.add("kinematics",
+               Kinematics::description()
+                   .addParametersDescriptionVector(
+                       "partonFluxes",
+                       PartonFluxFactory::get().describeParameters("BudnevElastic"),
+                       std::vector<ParametersList>(
+                           2, PartonFluxFactory::get().describeParameters("BudnevElastic").parameters()))
+                   .setDescription("Parton fluxes modelling"));
       desc.add("kinematicsGenerator", PhaseSpaceGeneratorFactory::get().describeParameters("kt2to4"));
       desc.add<bool>("storeAlphas", false)
           .setDescription("store the electromagnetic and strong coupling constants to the event content?");

--- a/CepGen/Process/FactorisedProcess.cpp
+++ b/CepGen/Process/FactorisedProcess.cpp
@@ -112,6 +112,7 @@ namespace cepgen {
     ParametersDescription FactorisedProcess::description() {
       auto desc = Process::description();
       desc.setDescription("Unnamed factorised process");
+      desc.add("kinematicsGenerator", PhaseSpaceGeneratorFactory::get().describeParameters("kt2to4"));
       desc.add<bool>("storeAlphas", false)
           .setDescription("store the electromagnetic and strong coupling constants to the event content?");
       return desc;

--- a/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
+++ b/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
@@ -36,7 +36,7 @@ namespace cepgen {
     auto set_flux_properties = [&kin](const Beam& beam, std::unique_ptr<PartonFlux>& flux) {
       auto params = beam.partonFluxParameters();
       const auto params_p_el = CollinearFluxFactory::get().describeParameters(
-          "EPAFlux", ParametersList().set("formFactors", kin.incomingBeams().formFactors()));
+          "EPAFlux", ParametersList().set("formFactors", beam.formFactors()));
       const auto params_p_inel = CollinearFluxFactory::get().describeParameters(
           "EPAFlux",
           ParametersList().set("formFactors",

--- a/CepGen/Process/PhaseSpaceGenerator2to4.cpp
+++ b/CepGen/Process/PhaseSpaceGenerator2to4.cpp
@@ -185,12 +185,12 @@ namespace cepgen {
       //--- four-momenta of the intermediate partons
       const double norm = 1. / proc_->wCM() / proc_->wCM() / s, prefac = 0.5 / std::sqrt(norm);
       {  // positive-z incoming parton collinear kinematics
-        const double tau1 = norm * proc_->q1().p2() / x1 / x1;
-        proc_->q1().setPz(+prefac * x1 * (1. - tau1)).setEnergy(+prefac * x1 * (1. + tau1));
+        const double tau1 = norm * proc_->q1().p2() / x1;
+        proc_->q1().setPz(+prefac * (x1 - tau1)).setEnergy(+prefac * (x1 + tau1));
       }
       {  // negative-z incoming parton collinear kinematics
-        const double tau2 = norm * proc_->q2().p2() / x2 / x2;
-        proc_->q2().setPz(-prefac * x2 * (1. - tau2)).setEnergy(+prefac * x2 * (1. + tau2));
+        const double tau2 = norm * proc_->q2().p2() / x2;
+        proc_->q2().setPz(-prefac * (x2 - tau2)).setEnergy(+prefac * (x2 + tau2));
       }
 
       CG_DEBUG_LOOP("2to4:partons") << "Squared c.m. energy = " << s << " GeV^2\n\t"
@@ -232,9 +232,8 @@ namespace cepgen {
 
     double central_weight_{0.};
   };
-
-  typedef PhaseSpaceGenerator2to4<PartonsKTPhaseSpaceGenerator> KT2to4;
-  typedef PhaseSpaceGenerator2to4<PartonsCollinearPhaseSpaceGenerator> Coll2to4;
 }  // namespace cepgen
+using KT2to4 = cepgen::PhaseSpaceGenerator2to4<cepgen::PartonsKTPhaseSpaceGenerator>;
+using Coll2to4 = cepgen::PhaseSpaceGenerator2to4<cepgen::PartonsCollinearPhaseSpaceGenerator>;
 REGISTER_PSGEN("kt2to4", KT2to4);
 REGISTER_PSGEN("coll2to4", Coll2to4);

--- a/CepGen/Process/Process.cpp
+++ b/CepGen/Process/Process.cpp
@@ -49,8 +49,8 @@ namespace cepgen {
           mp_(PDG::get().mass(PDG::proton)),
           mp2_(mp_ * mp_),
           rnd_gen_(RandomGeneratorFactory::get().build(steer<ParametersList>("randomGenerator"))) {
-      if (const auto& kin_params = steer<ParametersList>("kinematics"); !kin_params.empty())
-        kinematics().setParameters(kin_params);
+      if (const auto& kin = steer<ParametersList>("kinematics"); !kin.empty())
+        kin_.setParameters(kin);
       if (steer<bool>("hasEvent"))
         event_.reset(new Event);
     }
@@ -78,6 +78,7 @@ namespace cepgen {
         if (event_)
           log << "\n\t" << *event_;
       });
+      kin_ = proc.kin_;
       return *this;
     }
 
@@ -410,6 +411,7 @@ namespace cepgen {
       desc.add<bool>("hasEvent", true).setDescription("does the process carry an event definition");
       desc.add<ParametersDescription>("randomGenerator", RandomGeneratorFactory::get().describeParameters("stl"))
           .setDescription("random number generator engine");
+      desc.add("kinematics", Kinematics::description());
       return desc;
     }
 

--- a/CepGenAddOns/PythonWrapper/ConfigWriter.cpp
+++ b/CepGenAddOns/PythonWrapper/ConfigWriter.cpp
@@ -34,6 +34,10 @@ namespace cepgen {
     static std::string repr(const ParametersList& params, const std::string& key) {
       if (params.has<bool>(key))
         return params.get<bool>(key) ? "True" : "False";
+      else if (params.has<int>(key))
+        return "int(" + std::to_string(params.get<int>(key)) + ")";
+      else if (params.has<unsigned long long>(key))
+        return "int(" + std::to_string(params.get<unsigned long long>(key)) + ")";
       else if (params.has<std::string>(key))
         return "'" + utils::replaceAll(params.get<std::string>(key), "'", "\\'") + "'";
       else if (params.has<Limits>(key)) {

--- a/CepGenAddOns/PythonWrapper/PythonCardHandler.cpp
+++ b/CepGenAddOns/PythonWrapper/PythonCardHandler.cpp
@@ -145,17 +145,21 @@ namespace cepgen {
 
       // process definition
       if (auto process = plist_.get<ParametersList>("process"); !process.empty()) {
-        process += process.get<ParametersList>("processParameters");
-        process.erase("processParameters");
         auto& pkin = process.operator[]<ParametersList>("kinematics");
-        {
+        {  // remove extra layer of 'processParameters' and move it to the main process parameters block
+          process += process.get<ParametersList>("processParameters");
+          process.erase("processParameters");
+          if (process.has<int>("mode")) {  // move the kinematics mode from process to the main kinematics block
+            pkin.set("mode", (int)process.getAs<int, mode::Kinematics>("mode"));
+            process.erase("mode");
+          }
+        }
+        {  // remove extra layers of 'inKinematics' and 'outKinematics' and move them to the main kinematics block
           pkin += process.get<ParametersList>("inKinematics");
           process.erase("inKinematics");
           pkin += process.get<ParametersList>("outKinematics");
           process.erase("outKinematics");
         }
-        if (process.has<int>("mode"))
-          pkin.set("mode", (int)process.getAs<int, mode::Kinematics>("mode"));
         {
           if (auto& pkgen = process.operator[]<ParametersList>("kinematicsGenerator");
               pkgen.name<std::string>().empty())

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -217,11 +217,11 @@ private:
       return Vector{-2. * strfun_->F1(xbj, q2) / q2, strfun_->F2(xbj, q2) * xbj / q2};
     };
     const auto u1 = beams_mode_ == mode::Kinematics::ElasticInelastic
-                        ? compute_form_factors(*formfac1_, false, -t1(), mA2(), mX2())
+                        ? compute_form_factors(*formfac2_, false, -t1(), mA2(), mX2())
                         : compute_form_factors(
                               *formfac1_, kinematics().incomingBeams().positive().elastic(), -t1(), mA2(), mX2()),
                u2 = beams_mode_ == mode::Kinematics::ElasticInelastic
-                        ? compute_form_factors(*formfac2_, true, -t2(), mB2(), mY2())
+                        ? compute_form_factors(*formfac1_, true, -t2(), mB2(), mY2())
                         : compute_form_factors(
                               *formfac2_, kinematics().incomingBeams().negative().elastic(), -t2(), mB2(), mY2());
     const auto peripp = (u1.transposed() * m_em * u2)(0);

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -470,11 +470,10 @@ double LPAIR::pickin() {
 //---------------------------------------------------------------------------------------------
 
 bool LPAIR::orient() {
-  const auto re = 0.5 * inverseSqrtS();
-  eph1_ = re * (s2_ - mX2() + w12_);
-  eph2_ = re * (s1_ - mY2() - w12_);
-  //CG_LOG << eph1_ << ":" << eph2_;
-
+  if (const auto re = 0.5 * inverseSqrtS(); utils::positive(re)) {
+    eph1_ = re * (s2_ - mX2() + w12_);
+    eph2_ = re * (s1_ - mY2() - w12_);
+  }
   //----- central two-photon/lepton system
   if (ec4_ = eph1_ + eph2_; ec4_ < mc4_) {
     CG_WARNING("LPAIR:orient") << "ec4_ = " << ec4_ << " < mc4_ = " << mc4_ << "==> photon energies: " << eph1_ << ", "
@@ -558,7 +557,8 @@ bool LPAIR::orient() {
 //---------------------------------------------------------------------------------------------
 
 double LPAIR::computeWeight() {
-  mc4_ = std::sqrt(m_w4_);  // compute the two-photon energy for this point
+  if (mc4_ = std::sqrt(m_w4_); !utils::positive(mc4_))  // compute the two-photon energy for this point
+    return 0.;
 
   CG_DEBUG_LOOP("LPAIR:weight") << "Masses dump:\n\t"
                                 << "m1 = " << mA() << ", m2 = " << mB() << ", m3 = " << mX() << ", m4 = " << mc4_

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -84,7 +84,8 @@ public:
           << "gamma=" << gamma_cm_ << ", beta*gamma=" << beta_gamma_cm_;
     }
 
-    formfac_ = FormFactorsFactory::get().build(kinematics().incomingBeams().formFactors());
+    formfac1_ = FormFactorsFactory::get().build(kinematics().incomingBeams().positive().formFactors());
+    formfac2_ = FormFactorsFactory::get().build(kinematics().incomingBeams().negative().formFactors());
     strfun_ = StructureFunctionsFactory::get().build(kinematics().incomingBeams().structureFunctions());
 
     //--- first define the squared mass range for the diphoton/dilepton system
@@ -201,9 +202,10 @@ private:
         std::pow(4. / t1() / t2() / bb_, 2);
 
     // compute the electric/magnetic form factors for the two considered parton momenta transfers
-    const auto compute_form_factors = [this](bool elastic, double q2, double mi2, double mx2) -> Vector {
+    const auto compute_form_factors =
+        [this](formfac::Parameterisation& formfac, bool elastic, double q2, double mi2, double mx2) -> Vector {
       if (elastic) {  // trivial case for elastic photon emission
-        const auto ff = (*formfac_)(q2);
+        const auto ff = formfac(q2);
         return Vector{ff.FM, ff.FE};
       }
       if (!strfun_)
@@ -215,11 +217,13 @@ private:
       return Vector{-2. * strfun_->F1(xbj, q2) / q2, strfun_->F2(xbj, q2) * xbj / q2};
     };
     const auto u1 = beams_mode_ == mode::Kinematics::ElasticInelastic
-                        ? compute_form_factors(false, -t1(), mA2(), mX2())
-                        : compute_form_factors(kinematics().incomingBeams().positive().elastic(), -t1(), mA2(), mX2()),
+                        ? compute_form_factors(*formfac1_, false, -t1(), mA2(), mX2())
+                        : compute_form_factors(
+                              *formfac1_, kinematics().incomingBeams().positive().elastic(), -t1(), mA2(), mX2()),
                u2 = beams_mode_ == mode::Kinematics::ElasticInelastic
-                        ? compute_form_factors(true, -t2(), mB2(), mY2())
-                        : compute_form_factors(kinematics().incomingBeams().negative().elastic(), -t2(), mB2(), mY2());
+                        ? compute_form_factors(*formfac2_, true, -t2(), mB2(), mY2())
+                        : compute_form_factors(
+                              *formfac2_, kinematics().incomingBeams().negative().elastic(), -t2(), mB2(), mY2());
     const auto peripp = (u1.transposed() * m_em * u2)(0);
     CG_DEBUG_LOOP("LPAIR:peripp") << "bb = " << bb_ << ", qqq = " << q2dq_ << ", qdq = " << qdq << "\n\t"
                                   << "e-m matrix = " << m_em << "\n\t"
@@ -251,7 +255,7 @@ private:
   double p_cm_{0.}, mom_prefactor_{0.};
   double gamma_cm_{0.}, beta_gamma_cm_{0.};
 
-  std::unique_ptr<formfac::Parameterisation> formfac_;
+  std::unique_ptr<formfac::Parameterisation> formfac1_, formfac2_;
   std::unique_ptr<strfun::Parameterisation> strfun_;
 
   // mapped variables

--- a/test/physics/process_builder.cc
+++ b/test/physics/process_builder.cc
@@ -26,51 +26,43 @@
 using namespace std;
 
 int main(int argc, char* argv[]) {
-  string proc_name;
-  bool list;
-
-  cepgen::ArgumentsParser(argc, argv)
-      .addOptionalArgument("proc-name,p", "name of the process", &proc_name, "lpair")
-      .addOptionalArgument("list,l", "list all processes", &list, false)
-      .parse();
-
   cepgen::initialise();
 
-  if (list) {
-    CG_LOG.log([](auto& log) {
-      log << "List of modules registered in the runtime database:";
-      for (const auto& mod : cepgen::ProcessFactory::get().modules())
-        log << "\n> " << cepgen::utils::boldify(mod);
+  vector<string> processes;
+
+  cepgen::ArgumentsParser(argc, argv)
+      .addOptionalArgument("processes,p", "name of the processes", &processes, cepgen::ProcessFactory::get().modules())
+      .parse();
+
+  CG_LOG << "Will test process(es): " << processes << ".";
+  for (const auto& proc_name : processes) {
+    auto proc = cepgen::ProcessFactory::get().build(proc_name);
+    proc->initialise();
+    CG_DEBUG("main").log([&proc](auto& log) {
+      log << "Successfully built the process \"" << proc->name() << "\"!\n"
+          << " *) description: " << proc->description().description() << "\n"
+          << " *) has event? " << proc->hasEvent() << "\n";
+      if (proc->hasEvent()) {  //--- dump a typical event content
+        log << "    event content (invalid kinematics, only check the parentage):\n";
+        proc->event().dump();
+      }
     });
-    CG_TEST_SUMMARY;
-  }
-
-  if (proc_name.empty())
-    CG_TEST_SUMMARY;
-
-  CG_LOG << "Will build a process named \"" << proc_name << "\".";
-
-  auto proc = cepgen::ProcessFactory::get().build(proc_name);
-  proc->initialise();
-  //--- at this point, the process has been found
-  CG_LOG.log([&proc](auto& log) {
-    log << "Successfully built the process \"" << proc->name() << "\"!\n"
-        << " *) description: " << proc->description().description() << "\n"
-        << " *) has event? " << proc->hasEvent() << "\n";
-    if (proc->hasEvent()) {  //--- dump a typical event content
-      log << "    event content (invalid kinematics, only check the parentage):\n";
-      proc->event().dump();
-    }
-  });
-
-  if (proc_name == "lpair") {
-    CG_TEST_EQUAL(proc->hasEvent(), true, "LPAIR has event");
-    if (proc->hasEvent()) {
-      CG_TEST_EQUAL(proc->event().particles().size(), 9, "LPAIR particles content");
+    CG_TEST_EQUAL(proc->hasEvent(), true, "process has event");
+    if (!proc->hasEvent())
+      continue;
+    if (proc_name == "lpair" || proc_name == "pptoff") {
+      CG_TEST_EQUAL(proc->event().particles().size(), 9, proc_name + " particles content");
       const auto& cs = proc->event()(cepgen::Particle::Role::CentralSystem);
-      CG_TEST_EQUAL(cs.size(), 2, "LPAIR outgoing state");
-      CG_TEST_EQUAL(cs.at(0).pdgId(), 13, "LPAIR first outgoing particle");
-      CG_TEST_EQUAL(cs.at(1).pdgId(), 13, "LPAIR second outgoing particle");
+      CG_TEST_EQUAL(cs.size(), 2, proc_name + " outgoing state");
+      CG_TEST_EQUAL(cs.at(0).integerPdgId(), +13, proc_name + " first outgoing particle");
+      CG_TEST_EQUAL(cs.at(1).integerPdgId(), -13, proc_name + " second outgoing particle");
+    }
+    if (proc_name == "pptoww") {
+      CG_TEST_EQUAL(proc->event().particles().size(), 9, proc_name + " particles content");
+      const auto& cs = proc->event()(cepgen::Particle::Role::CentralSystem);
+      CG_TEST_EQUAL(cs.size(), 2, proc_name + " outgoing state");
+      CG_TEST_EQUAL(cs.at(0).integerPdgId(), +24, proc_name + " first outgoing particle");
+      CG_TEST_EQUAL(cs.at(1).integerPdgId(), -24, proc_name + " second outgoing particle");
     }
   }
 


### PR DESCRIPTION
This PR strips the unique form factors definition from the two-beam parameters space to add it as an extra attribute to single-beam parameters.
This allows to cope with asymmetric collisions schemes, such as Pb-p, ep, ... both for LPAIR or factorised processes.

Additionally, a ep "LHeC-like" configuration for dileptons is integrated.

It also fixes a long-standing issue when parsing the structure functions for kt-factorised (or collinear in general) matrix elements, where modelling was overridden by the LUXlike parameterisation.