### PR TITLE
LPAIR: allows asymmetric beams to be handled

### DIFF
--- a/Cards/lpair_ep_cfg.py
+++ b/Cards/lpair_ep_cfg.py
@@ -31,7 +31,7 @@ generator = _gen.clone(
 text = cepgen.Module('text', # histogramming/ASCII output capability
     histVariables={
         'm(4)': cepgen.Parameters(xrange=(0., 25.), nbins=20, log=False),
-        'pt(7):pt(8)': cepgen.Parameters(xrange=(0., 5.), yrange=(0., 5.), log=True)
+        'pt(7):pt(8)': cepgen.Parameters(xrange=(0., 50.), yrange=(0., 50.), log=True)
     }
 )
 #lhef = cepgen.Module('lhef', filename='test.lhe')

--- a/test/validation/compare_dilepton_ep_kt.cc
+++ b/test/validation/compare_dilepton_ep_kt.cc
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
   bool ratio_plot;
   cepgen::ArgumentsParser(argc, argv)
       .addOptionalArgument(
-          "processes,P", "processes to generate", &processes, vector<string>{/*"lpair",*/ "pptoff", "mg5_aMC"})
+          "processes,P", "processes to generate", &processes, vector<string>{"lpair", "pptoff", "mg5_aMC"})
       .addOptionalArgument("num-gen,n", "number of events to generate", &num_gen, 10'000)
       .addOptionalArgument("plotter,p", "type of plotter to user", &plotter, "root")
       .addOptionalArgument("ratio,r", "draw the ratio plot", &ratio_plot, false)


### PR DESCRIPTION
This PR fixes the issue encountered with asymmetric beams in LPAIR, namely the cross section cancels due to the lack of handling of the central two-beam system boost.
Furthermore, the t/q^2 range treatment is improved.