### PR TITLE
Allowed values for parameters

### DIFF
--- a/CepGen/Core/ParametersDescription.cpp
+++ b/CepGen/Core/ParametersDescription.cpp
@@ -257,4 +257,35 @@ namespace cepgen {
     }
     return os << "{invalid}";
   }
+
+  bool ParametersDescription::ParameterValues::empty() const { return int_vals_.empty() && str_vals_.empty(); }
+
+  ParametersDescription::ParameterValues& ParametersDescription::ParameterValues::allow(int val,
+                                                                                        const std::string& descr) {
+    int_vals_[val] = descr;
+    return *this;
+  }
+
+  ParametersDescription::ParameterValues& ParametersDescription::ParameterValues::allow(const std::string& val,
+                                                                                        const std::string& descr) {
+    str_vals_[val] = descr;
+    return *this;
+  }
+
+  bool ParametersDescription::ParameterValues::validate(int val) const {
+    if (empty())
+      return true;
+    return int_vals_.count(val) > 0;
+  }
+
+  bool ParametersDescription::ParameterValues::validate(const std::string& val) const {
+    if (empty())
+      return true;
+    return str_vals_.count(val) > 0;
+  }
+
+  std::ostream& operator<<(std::ostream& os, const ParametersDescription::ParameterValues& vals) {
+    return os << "Allowed values: integer" << utils::repr(utils::keys(vals.int_vals_)) << ", string"
+              << utils::repr(utils::keys(vals.str_vals_));
+  }
 }  // namespace cepgen

--- a/CepGen/Core/ParametersDescription.cpp
+++ b/CepGen/Core/ParametersDescription.cpp
@@ -208,7 +208,7 @@ namespace cepgen {
   const ParametersList& ParametersDescription::parameters() const { return *this; }
 
   ParametersList ParametersDescription::validate(const ParametersList& user_params) const {
-    ParametersList plist = parameters();
+    auto plist = parameters();  // first copy the current parameters handled
     plist += user_params;
     for (const auto& key : keysOf<std::vector<ParametersList> >()) {
       if (user_params.has<std::vector<ParametersList> >(key)) {  // vector{ParametersList}

--- a/CepGen/Core/ParametersDescription.cpp
+++ b/CepGen/Core/ParametersDescription.cpp
@@ -237,17 +237,18 @@ namespace cepgen {
           std::ostringstream os;
           os << "Invalid value for key '" << key << "'"
              << (!desc.description().empty() ? " ("s + desc.description() + ")" : "") << ".\n"
-             << desc.values() << ", got '" << utils::toString(val) + "'.";
+             << "Allowed values:\n";
+          for (const auto& kv : desc.values().allowed())
+            os << " * " << kv.first << (!kv.second.empty() ? " (" + kv.second + ")" : "") << "\n";
+          os << "Steered value: '" << utils::toString(val) + "'.";
           return os.str();
         };
         if (plist.has<int>(kv.first) && !kv.second.values().validate(plist.get<int>(kv.first)))
           throw CG_FATAL("ParametersDescription:validate")
-              << validation_error(kv.first, plist.get<int>(kv.first), kv.second) << "\n"
-              << "Full description: " << (*this) << ".";
+              << validation_error(kv.first, plist.get<int>(kv.first), kv.second);
         if (plist.has<std::string>(kv.first) && !kv.second.values().validate(plist.get<std::string>(kv.first)))
           throw CG_FATAL("ParametersDescription:validate")
-              << validation_error(kv.first, plist.get<std::string>(kv.first), kv.second) << "\n"
-              << "Full description: " << (*this) << ".";
+              << validation_error(kv.first, plist.get<std::string>(kv.first), kv.second);
       }
     }
     CG_DEBUG_LOOP("ParametersDescription:validate") << "Validating user parameters:\n"

--- a/CepGen/Core/ParametersDescription.cpp
+++ b/CepGen/Core/ParametersDescription.cpp
@@ -59,6 +59,7 @@ namespace cepgen {
         add<ParametersDescription>(key, oth.get(key)).setDescription(desc);
       }
     obj_descr_.insert(oth.obj_descr_.begin(), oth.obj_descr_.end());
+    obj_values_.append(oth.obj_values_);
     ParametersList::operator+=(oth);
     return *this;
   }
@@ -273,6 +274,13 @@ namespace cepgen {
   ParametersDescription::ParameterValues& ParametersDescription::ParameterValues::allow(const std::string& val,
                                                                                         const std::string& descr) {
     str_vals_[val] = descr;
+    return *this;
+  }
+
+  ParametersDescription::ParameterValues& ParametersDescription::ParameterValues::append(
+      const ParametersDescription::ParameterValues& oth) {
+    int_vals_.insert(oth.int_vals_.begin(), oth.int_vals_.end());
+    str_vals_.insert(oth.str_vals_.begin(), oth.str_vals_.end());
     return *this;
   }
 

--- a/CepGen/Core/ParametersDescription.cpp
+++ b/CepGen/Core/ParametersDescription.cpp
@@ -56,8 +56,8 @@ namespace cepgen {
     for (const auto& key : ParametersList::keysOf<std::vector<ParametersList> >())
       // particular case if one describes a set of key-indexed parameters list as a vector of parameters lists
       if (static_cast<ParametersList>(oth).has<ParametersList>(key)) {
-        ParametersList::erase(key);
         const auto& desc = get(key);
+        ParametersList::erase(key);
         add<ParametersDescription>(key, oth.get(key))
             .setDescription(desc.description())
             .allowedValues()

--- a/CepGen/Core/ParametersDescription.h
+++ b/CepGen/Core/ParametersDescription.h
@@ -98,17 +98,20 @@ namespace cepgen {
       /// Short printout of allowed parameter values
       friend std::ostream& operator<<(std::ostream&, const ParameterValues&);
 
-      ParameterValues& append(const ParameterValues&);  ///< Merge two collections of allowed values
-      bool empty() const;                               ///< Check if a parameter has a limited set of allowed values
+      ParameterValues& append(const ParameterValues&);         ///< Merge two collections of allowed values
+      inline bool allAllowed() const { return all_allowed_; }  ///< Are all values allowed?
+      bool empty() const;  ///< Check if a parameter has a limited set of allowed values
 
       ParameterValues& allow(int, const std::string& = "");                 ///< Allow an integer value for a parameter
       ParameterValues& allow(const std::string&, const std::string& = "");  ///< Allow a string value for a parameter
+      void allowAll() { all_allowed_ = true; }             ///< Allow all values to be set for a parameter
       std::map<std::string, std::string> allowed() const;  ///< Helper list of allowed values (all types) for a parameter
 
       bool validate(int) const;                 ///< Check if an integer value is allowed for a parameter
       bool validate(const std::string&) const;  ///< Check if a string value is allowed for a parameter
 
     private:
+      bool all_allowed_{true};
       std::map<int, std::string> int_vals_;
       std::map<std::string, std::string> str_vals_;
     };

--- a/CepGen/Core/ParametersDescription.h
+++ b/CepGen/Core/ParametersDescription.h
@@ -95,12 +95,14 @@ namespace cepgen {
     public:
       ParameterValues() {}
 
+      /// Short printout of allowed parameter values
       friend std::ostream& operator<<(std::ostream&, const ParameterValues&);
 
       bool empty() const;  ///< Check if a parameter has a limited set of allowed values
 
       ParameterValues& allow(int, const std::string& = "");                 ///< Allow an integer value for a parameter
       ParameterValues& allow(const std::string&, const std::string& = "");  ///< Allow a string value for a parameter
+      std::map<std::string, std::string> allowed() const;  ///< Helper list of allowed values (all types) for a parameter
 
       bool validate(int) const;                 ///< Check if an integer value is allowed for a parameter
       bool validate(const std::string&) const;  ///< Check if a string value is allowed for a parameter

--- a/CepGen/Core/ParametersDescription.h
+++ b/CepGen/Core/ParametersDescription.h
@@ -102,9 +102,6 @@ namespace cepgen {
       inline bool allAllowed() const { return all_allowed_; }  ///< Are all values allowed?
       bool empty() const;  ///< Check if a parameter has a limited set of allowed values
 
-      ParameterValues& allow(int, const std::string& = "");                 ///< Allow an integer value for a parameter
-      ParameterValues& allow(const std::string&, const std::string& = "");  ///< Allow a string value for a parameter
-      void allowAll() { all_allowed_ = true; }             ///< Allow all values to be set for a parameter
       std::map<std::string, std::string> allowed() const;  ///< Helper list of allowed values (all types) for a parameter
 
       bool validate(int) const;                 ///< Check if an integer value is allowed for a parameter
@@ -114,12 +111,17 @@ namespace cepgen {
       bool all_allowed_{true};
       std::map<int, std::string> int_vals_;
       std::map<std::string, std::string> str_vals_;
+      friend ParametersDescription;
     };
-
-    inline const ParameterValues& values() const { return obj_values_; }  ///< Possible values for a parameter
-    inline ParameterValues& values() { return obj_values_; }              ///< Possible values for a parameter
+    inline const ParameterValues& allowedValues() const { return obj_values_; }  ///< Possible values for a parameter
+    ParametersDescription& allow(int, const std::string& = "");  ///< Allow an integer value for a parameter
+    ParametersDescription& allow(const std::string&,
+                                 const std::string& = "");  ///< Allow a string value for a parameter
+    void allowAll() { obj_values_.all_allowed_ = true; }    ///< Allow all values to be set for a parameter
 
   private:
+    inline ParameterValues& allowedValues() { return obj_values_; }  ///< Possible values for a parameter
+
     std::string mod_key_, mod_descr_;
     bool is_vec_params_{false};
     std::map<std::string, ParametersDescription> obj_descr_;

--- a/CepGen/Core/ParametersDescription.h
+++ b/CepGen/Core/ParametersDescription.h
@@ -98,7 +98,8 @@ namespace cepgen {
       /// Short printout of allowed parameter values
       friend std::ostream& operator<<(std::ostream&, const ParameterValues&);
 
-      bool empty() const;  ///< Check if a parameter has a limited set of allowed values
+      ParameterValues& append(const ParameterValues&);  ///< Merge two collections of allowed values
+      bool empty() const;                               ///< Check if a parameter has a limited set of allowed values
 
       ParameterValues& allow(int, const std::string& = "");                 ///< Allow an integer value for a parameter
       ParameterValues& allow(const std::string&, const std::string& = "");  ///< Allow a string value for a parameter

--- a/CepGen/Core/ParametersDescription.h
+++ b/CepGen/Core/ParametersDescription.h
@@ -78,32 +78,46 @@ namespace cepgen {
     ParametersDescription& addParametersDescriptionVector(const std::string&,
                                                           const ParametersDescription&,
                                                           const std::vector<ParametersList>& def = {});
-    /// Human-readable description of all parameters and their default value
-    std::string describe(size_t offset = 0) const;
-    /// List of parameters associated to this description object
-    ParametersList& parameters();
-    /// List of parameters associated to this description object
-    const ParametersList& parameters() const;
-    /// Ensure the description exists
-    bool has(const std::string&) const;
-    /// Get the description of a sub-object
-    const ParametersDescription& get(const std::string&) const;
-    /// Validate a set of used-steered parameters
-    ParametersList validate(const ParametersList&) const;
-    /// Set the parameters value for this description object
-    ParametersDescription steer(const ParametersList&) const;
+    std::string describe(size_t offset = 0) const;  ///< Human-readable description of parameters and their default value
+    ParametersList& parameters();                   ///< List of parameters associated to this description object
+    const ParametersList& parameters() const;       ///< List of parameters associated to this description object
+    bool has(const std::string&) const;             ///< Ensure the description exists
+    const ParametersDescription& get(const std::string&) const;  ///< Get the description of a sub-object
+    ParametersList validate(const ParametersList&) const;        ///< Validate a set of used-steered parameters
+    ParametersDescription steer(const ParametersList&) const;    ///< Set parameters value for this description object
 
-    /// Parameter type
-    enum struct Type { Value, Parameters, Module, ParametersVector };
-    /// Human-readable description of a parameter type
-    friend std::ostream& operator<<(std::ostream&, const Type&);
-    /// Get the type of parameter considered
-    Type type() const;
+    enum struct Type { Value, Parameters, Module, ParametersVector };  ///< Parameter type
+    friend std::ostream& operator<<(std::ostream&, const Type&);       ///< Human-readable description of parameter type
+    Type type() const;                                                 ///< Get the type of parameter considered
+
+    /// A collection of valid values for a given parameter
+    class ParameterValues {
+    public:
+      ParameterValues() {}
+
+      friend std::ostream& operator<<(std::ostream&, const ParameterValues&);
+
+      bool empty() const;  ///< Check if a parameter has a limited set of allowed values
+
+      ParameterValues& allow(int, const std::string& = "");                 ///< Allow an integer value for a parameter
+      ParameterValues& allow(const std::string&, const std::string& = "");  ///< Allow a string value for a parameter
+
+      bool validate(int) const;                 ///< Check if an integer value is allowed for a parameter
+      bool validate(const std::string&) const;  ///< Check if a string value is allowed for a parameter
+
+    private:
+      std::map<int, std::string> int_vals_;
+      std::map<std::string, std::string> str_vals_;
+    };
+
+    inline const ParameterValues& values() const { return obj_values_; }  ///< Possible values for a parameter
+    inline ParameterValues& values() { return obj_values_; }              ///< Possible values for a parameter
 
   private:
     std::string mod_key_, mod_descr_;
     bool is_vec_params_{false};
     std::map<std::string, ParametersDescription> obj_descr_;
+    ParameterValues obj_values_;
   };
   template <>
   ParametersDescription& ParametersDescription::setKey<std::string>(const std::string&);

--- a/CepGen/Core/SteeredObject.h
+++ b/CepGen/Core/SteeredObject.h
@@ -61,7 +61,7 @@ namespace cepgen {
     virtual inline void setParameters(const ParametersList& params) override {
       if (params.empty())
         return;
-      Steerable::setParameters(T::description().validate(params));
+      Steerable::setParameters(params);
 #define __TYPE_ENUM(type, map_name) \
   for (const auto& kv : map_name)   \
     params_.fill(kv.first, kv.second);

--- a/CepGen/Core/SteeredObject.h
+++ b/CepGen/Core/SteeredObject.h
@@ -61,7 +61,7 @@ namespace cepgen {
     virtual inline void setParameters(const ParametersList& params) override {
       if (params.empty())
         return;
-      Steerable::setParameters(params);
+      Steerable::setParameters(T::description().validate(params));
 #define __TYPE_ENUM(type, map_name) \
   for (const auto& kv : map_name)   \
     params_.fill(kv.first, kv.second);

--- a/CepGen/Physics/IncomingBeams.cpp
+++ b/CepGen/Physics/IncomingBeams.cpp
@@ -269,7 +269,12 @@ namespace cepgen {
     desc.add<std::vector<double> >("energies", {}).setDescription("Beam energies (in GeV/c)");
     desc.add<double>("sqrtS", 0.).setDescription("Two-beam centre of mass energy (in GeV)");
     desc.addAs<int, mode::Kinematics>("mode", mode::Kinematics::invalid)
-        .setDescription("Process kinematics mode (1 = elastic, (2-3) = single-dissociative, 4 = double-dissociative)");
+        .setDescription("Process kinematics mode")
+        .values()
+        .allow(1, "elastic")
+        .allow(2, "elastic-inelastic")
+        .allow(3, "inelastic-elastic")
+        .allow(4, "double-dissociative");
     desc.addParametersDescriptionVector(
             "formFactors",
             FormFactorsFactory::get().describeParameters(formfac::gFFStandardDipoleHandler),

--- a/CepGen/Physics/IncomingBeams.cpp
+++ b/CepGen/Physics/IncomingBeams.cpp
@@ -270,7 +270,6 @@ namespace cepgen {
     desc.add<double>("sqrtS", 0.).setDescription("Two-beam centre of mass energy (in GeV)");
     desc.addAs<int, mode::Kinematics>("mode", mode::Kinematics::invalid)
         .setDescription("Process kinematics mode")
-        .values()
         .allow(1, "elastic")
         .allow(2, "elastic-inelastic")
         .allow(3, "inelastic-elastic")

--- a/CepGen/Physics/IncomingBeams.cpp
+++ b/CepGen/Physics/IncomingBeams.cpp
@@ -274,7 +274,8 @@ namespace cepgen {
         .allow(1, "elastic")
         .allow(2, "elastic-inelastic")
         .allow(3, "inelastic-elastic")
-        .allow(4, "double-dissociative");
+        .allow(4, "double-dissociative")
+        .allowAll();
     desc.addParametersDescriptionVector(
             "formFactors",
             FormFactorsFactory::get().describeParameters(formfac::gFFStandardDipoleHandler),

--- a/CepGen/Utils/GSLDerivator.cpp
+++ b/CepGen/Utils/GSLDerivator.cpp
@@ -35,7 +35,6 @@ namespace cepgen {
         desc.setDescription("GSL numerical differentiation algorithm");
         desc.addAs<int, Mode>("mode", Mode::central)
             .setDescription("mode used for the adaptive difference algorithm")
-            .values()
             .allow(0, "central")
             .allow(1, "forward")
             .allow(2, "backward");

--- a/CepGen/Utils/GSLDerivator.cpp
+++ b/CepGen/Utils/GSLDerivator.cpp
@@ -34,7 +34,11 @@ namespace cepgen {
         auto desc = Derivator::description();
         desc.setDescription("GSL numerical differentiation algorithm");
         desc.addAs<int, Mode>("mode", Mode::central)
-            .setDescription("mode used for the adaptive difference algorithm (0=central, 1=forward, 2=backward)");
+            .setDescription("mode used for the adaptive difference algorithm")
+            .values()
+            .allow(0, "central")
+            .allow(1, "forward")
+            .allow(2, "backward");
         return desc;
       }
 

--- a/CepGenAddOns/CTMLWrapper/CTMLDocumentationGenerator.cpp
+++ b/CepGenAddOns/CTMLWrapper/CTMLDocumentationGenerator.cpp
@@ -121,6 +121,18 @@ private:
                     .AppendText("(default value: ")
                     .AppendChild(CTML::Node("code", desc.parameters().getString(key, false)))
                     .AppendText(")"));
+          if (const auto& allowed_vals = desc.get(key).allowedValues(); !allowed_vals.empty()) {
+            item.AppendText(". Allowed values:");
+            CTML::Node itparams("ul");
+            for (const auto& it : allowed_vals.allowed()) {
+              CTML::Node val("li");
+              val.AppendChild(CTML::Node("code", it.first));
+              if (!it.second.empty())
+                val.AppendText(" (" + it.second + ")");
+              itparams.AppendChild(val);
+            }
+            item.AppendChild(itparams);
+          }
         } else if (subdesc_type == ParametersDescription::Type::ParametersVector) {
           item.AppendText(" vector of parameters");
           if (!subdesc.description().empty())

--- a/CepGenAddOns/Herwig6Wrapper/AlphaS.cpp
+++ b/CepGenAddOns/Herwig6Wrapper/AlphaS.cpp
@@ -40,7 +40,6 @@ namespace cepgen {
         initialise();
         desc.add<int>("mode", 1)
             .setDescription("running mode")
-            .values()
             .allow(1, "two-loop flavour thresholds")
             .allow(2, "ratio of mode-1 with 5-flavour beta with Lambda=QCDL3")
             .allow(3, "one-loop with 5-flavour beta and Lambda=QCDL3");

--- a/CepGenAddOns/Herwig6Wrapper/AlphaS.cpp
+++ b/CepGenAddOns/Herwig6Wrapper/AlphaS.cpp
@@ -38,9 +38,12 @@ namespace cepgen {
         auto desc = cepgen::Coupling::description();
         desc.setDescription("Herwig6 modelling of alpha(S) running");
         initialise();
-        desc.add<int>("mode", 1).setDescription(
-            "running mode (1=two-loop flavour thresholds, 2=ratio of mode-1 with 5-flavour beta with Lambda=QCDL3, "
-            "3=one-loop with 5-flavour beta and Lambda=QCDL3)");
+        desc.add<int>("mode", 1)
+            .setDescription("running mode")
+            .values()
+            .allow(1, "two-loop flavour thresholds")
+            .allow(2, "ratio of mode-1 with 5-flavour beta with Lambda=QCDL3")
+            .allow(3, "one-loop with 5-flavour beta and Lambda=QCDL3");
         desc.add<int>("ncolo", hwpram_.ncolo).setDescription("number of colours to consider");
         desc.add<double>("qcdlam", hwpram_.qcdlam).setDescription("5-flavour Lambda_MS-bar at large x/z");
         desc.add<double>("qcdl5", hwpram_.qcdl5).setDescription("5-flavour Lambda_MC");

--- a/CepGenAddOns/Pythia6Wrapper/AlphaEM.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/AlphaEM.cpp
@@ -38,7 +38,6 @@ namespace cepgen {
         desc.setDescription("Pythia6 modelling of alpha(EM) running");
         desc.add<int>("mode", mstu(101))
             .setDescription("procedure for alpha(EM) evaluation")
-            .values()
             .allow(0, "fix at 'fixedAlphaEM'")
             .allow(1, "running accounting to fermion loops")
             .allow(2, "fix with low-high Q^2 splitting");

--- a/CepGenAddOns/Pythia6Wrapper/AlphaEM.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/AlphaEM.cpp
@@ -37,9 +37,11 @@ namespace cepgen {
         auto desc = cepgen::Coupling::description();
         desc.setDescription("Pythia6 modelling of alpha(EM) running");
         desc.add<int>("mode", mstu(101))
-            .setDescription(
-                "procedure for alpha(EM) evaluation (0=fix at 'fixedAlphaEM', 1=running accounting to fermion loops, "
-                "2=fix with low-high Q^2 splitting)");
+            .setDescription("procedure for alpha(EM) evaluation")
+            .values()
+            .allow(0, "fix at 'fixedAlphaEM'")
+            .allow(1, "running accounting to fermion loops")
+            .allow(2, "fix with low-high Q^2 splitting");
         desc.add<double>("fixedAlphaEM", paru(101))
             .setDescription("electromagnetic fine structure constant at vanishing mom.transfer");
         desc.add<double>("sin2ThetaW", paru(102)).setDescription("weak mixing angle of the standard electroweak model");

--- a/CepGenAddOns/Pythia6Wrapper/AlphaS.cpp
+++ b/CepGenAddOns/Pythia6Wrapper/AlphaS.cpp
@@ -41,17 +41,20 @@ namespace cepgen {
         auto desc = cepgen::Coupling::description();
         desc.setDescription("Pythia6 modelling of alpha(S) running");
         desc.add<int>("order", mstu(111))
-            .setDescription(
-                "order of alpha(S) evaluation (0=fixed at 'fixedAlphaS', 1=1st order running, 2=2nd order running)");
+            .setDescription("order of alpha(S) evaluation")
+            .allow(0, "fixed at 'fixedAlphaS'")
+            .allow(1, "1st order running")
+            .allow(2, "2nd order running");
         desc.add<int>("nf", mstu(112)).setDescription("nominal number of ﬂavours assumed in alpha(s) expression");
         desc.add<int>("minNf", mstu(113))
             .setDescription("minimum number of ﬂavours that may be assumed in alpha(S) expression");
         desc.add<int>("maxNf", mstu(114))
             .setDescription("minimum number of ﬂavours that may be assumed in alpha(S) expression");
         desc.add<int>("singularityTreatment", mstu(115))
-            .setDescription(
-                "treatment of alpha(S) singularities for Q^2->0 (0=allow divergence, 1=log-softening, 2=freeze under "
-                "Q^2 transition value)");
+            .setDescription("treatment of alpha(S) singularities for Q^2->0")
+            .allow(0, "allow divergence")
+            .allow(1, "log-softening")
+            .allow(2, "freeze under Q^2 transition value");
         desc.add<double>("fixedAlphaS", paru(111))
             .setDescription(
                 "fix alpha(S) value assumed when order=0 (and also in parton showers when alpha(S) is assumed fix "

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -172,7 +172,6 @@ public:
   static ParametersDescription description() {
     auto desc = proc::Process::description();
     desc.setDescription("γγ → l⁺l¯ (LPAIR)");
-    desc.add<int>("nopt", 0).setDescription("Optimised mode? (inherited from LPAIR, by default disabled = 0)");
     desc.addAs<int, pdgid_t>("pair", PDG::muon).setDescription("Lepton pair considered");
     desc.add<bool>("symmetrise", false).setDescription("Symmetrise along z the central system?");
     desc.add<bool>("randomiseCharge", true).setDescription("randomise the charges of the two central fermions?");

--- a/CepGenProcesses/PPtoFF.cpp
+++ b/CepGenProcesses/PPtoFF.cpp
@@ -49,7 +49,10 @@ public:
     desc.setDescription("γγ → f⁺f¯");
     desc.addAs<int, pdgid_t>("pair", PDG::muon).setDescription("type of central particles emitted");
     desc.addAs<int, Mode>("method", Mode::offShell)
-        .setDescription("Matrix element computation method (0 = on-shell, 1 = off-shell)");
+        .setDescription("Matrix element computation method")
+        .values()
+        .allow(0, "on-shell")
+        .allow(1, "off-shell");
     desc.add("offShellParameters", OffShellParameters::description());
     return desc;
   }

--- a/CepGenProcesses/PPtoFF.cpp
+++ b/CepGenProcesses/PPtoFF.cpp
@@ -50,7 +50,6 @@ public:
     desc.addAs<int, pdgid_t>("pair", PDG::muon).setDescription("type of central particles emitted");
     desc.addAs<int, Mode>("method", Mode::offShell)
         .setDescription("Matrix element computation method")
-        .values()
         .allow(0, "on-shell")
         .allow(1, "off-shell");
     desc.add("offShellParameters", OffShellParameters::description());

--- a/CepGenProcesses/PPtoWW.cpp
+++ b/CepGenProcesses/PPtoWW.cpp
@@ -68,7 +68,6 @@ public:
     desc.add<bool>("ktFactorised", true);
     desc.add<int>("method", 1)
         .setDescription("Matrix element computation method")
-        .values()
         .allow(0, "on-shell")
         .allow(1, "off-shell by Nachtmann et al.");
     desc.add<ParametersDescription>("polarisationStates", PolarisationState::description());

--- a/CepGenProcesses/PPtoWW.cpp
+++ b/CepGenProcesses/PPtoWW.cpp
@@ -67,7 +67,10 @@ public:
     desc.setDescription("γγ → W⁺W¯");
     desc.add<bool>("ktFactorised", true);
     desc.add<int>("method", 1)
-        .setDescription("Matrix element computation method (0 = on-shell, 1 = off-shell by Nachtmann et al.)");
+        .setDescription("Matrix element computation method")
+        .values()
+        .allow(0, "on-shell")
+        .allow(1, "off-shell by Nachtmann et al.");
     desc.add<ParametersDescription>("polarisationStates", PolarisationState::description());
     desc += NachtmannAmplitudes::description();
     return desc;


### PR DESCRIPTION
This PR introduces the capability to validate some (integer or string, currently) values of a certain user-steered parameter through its description helper.
In case of failure, an exception is thrown to abort the execution.
This allows to normalise the description of "enum-like" parameters and ease the spotting of invalid parameters.