### PR TITLE
Herwig6 structure functions

### DIFF
--- a/CepGenAddOns/Herwig6Wrapper/Herwig6Interface.cpp
+++ b/CepGenAddOns/Herwig6Wrapper/Herwig6Interface.cpp
@@ -25,6 +25,7 @@
 namespace {
   extern "C" {
   void hwigin_();
+  void hwsfun_(double&, double&, int&, int&, double dist[13], int&);
   double hwuaem_(double&);
   double hwualf_(int&, double&);
   }
@@ -47,5 +48,10 @@ namespace cepgen {
     }
     double hwuaem(double q2) { return hwuaem_(q2); }
     double hwualf(int mode, double q2) { return hwualf_(mode, q2); }
+    double hwsfun(double xbj, double q2, int idhad, int nset, int ibeam) {
+      std::array<double, 13> dist;
+      hwsfun_(xbj, q2, idhad, nset, dist.data(), ibeam);
+      return dist[0];
+    }
   }  // namespace herwig6
 }  // namespace cepgen

--- a/CepGenAddOns/Herwig6Wrapper/Herwig6Interface.h
+++ b/CepGenAddOns/Herwig6Wrapper/Herwig6Interface.h
@@ -53,6 +53,7 @@ namespace cepgen {
     void initialise();
     double hwuaem(double q2);
     double hwualf(int mode, double q2);
+    double hwsfun(double xbj, double q2, int idhad, int nset, int ibeam);
   }  // namespace herwig6
 }  // namespace cepgen
 

--- a/CepGenAddOns/Herwig6Wrapper/StructureFunctions.cpp
+++ b/CepGenAddOns/Herwig6Wrapper/StructureFunctions.cpp
@@ -51,7 +51,6 @@ namespace cepgen {
             .allow(6, "MRST98LO (central alpha(S)/gluon)")
             .allow(7, "MRST98LO (higher gluon)")
             .allow(8, "MRST98LO (average of central and higher gluon)");
-        ;
         return desc;
       }
 

--- a/CepGenAddOns/Herwig6Wrapper/StructureFunctions.cpp
+++ b/CepGenAddOns/Herwig6Wrapper/StructureFunctions.cpp
@@ -41,13 +41,17 @@ namespace cepgen {
             .allow(75, "neutron")
             .allow(91, "antiproton")
             .allow(93, "antineutron");
-        desc.add<int>("nset", 5)
+        desc.add<int>("nset", 8)
             .setDescription("structure functions set")
-            .allow(1, "Duke & Owens for soft glue")
-            .allow(2, "Duke & Owens for hard glue")
-            .allow(3, "Eichten & al. nucleons only")
-            .allow(4, "Eichten & al. nucleons only")
-            .allow(5, "Owens");
+            .allow(1, "Duke & Owens set 1 (for soft/hard glue)")
+            .allow(2, "Duke & Owens set 2 (for soft/hard glue)")
+            .allow(3, "Eichten & al. set 1 (nucleons only)")
+            .allow(4, "Eichten & al. set 2 (nucleons only)")
+            .allow(5, "Owens set 1.1")
+            .allow(6, "MRST98LO (central alpha(S)/gluon)")
+            .allow(7, "MRST98LO (higher gluon)")
+            .allow(8, "MRST98LO (average of central and higher gluon)");
+        ;
         return desc;
       }
 

--- a/CepGenAddOns/Herwig6Wrapper/StructureFunctions.cpp
+++ b/CepGenAddOns/Herwig6Wrapper/StructureFunctions.cpp
@@ -1,0 +1,61 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Modules/StructureFunctionsFactory.h"
+#include "CepGen/StructureFunctions/Parameterisation.h"
+#include "CepGen/Utils/Message.h"
+#include "CepGenAddOns/Herwig6Wrapper/Herwig6Interface.h"
+
+namespace cepgen {
+  namespace herwig6 {
+    class StructureFunctions final : public strfun::Parameterisation {
+    public:
+      explicit StructureFunctions(const ParametersList& params)
+          : strfun::Parameterisation(params), idhad_(steer<int>("idhad")), nset_(steer<int>("nset")) {}
+
+      static ParametersDescription description() {
+        initialise();
+        auto desc = strfun::Parameterisation::description();
+        desc.setDescription("Herwig 6 structure functions evaluator");
+        desc.add<int>("idhad", 73)
+            .setDescription("type of hadron")
+            .allow(30, "pi-")
+            .allow(38, "pi+")
+            .allow(59, "photon")
+            .allow(73, "proton")
+            .allow(75, "neutron")
+            .allow(91, "antiproton")
+            .allow(93, "antineutron");
+        desc.add<int>("nset", 5)
+            .setDescription("structure functions set")
+            .allow(1, "Duke & Owens for soft glue")
+            .allow(2, "Duke & Owens for hard glue")
+            .allow(3, "Eichten & al. nucleons only")
+            .allow(4, "Eichten & al. nucleons only")
+            .allow(5, "Owens");
+        return desc;
+      }
+
+    private:
+      void eval() override { setF2(hwsfun(args_.xbj, args_.q2, idhad_, nset_, 2)); }
+      const int idhad_, nset_;
+    };
+  }  // namespace herwig6
+}  // namespace cepgen
+using Herwig6StructureFunctions = cepgen::herwig6::StructureFunctions;
+REGISTER_STRFUN("herwig6", 403, Herwig6StructureFunctions);


### PR DESCRIPTION
This PR adds the support for Herwig 6 structure functions retrieval. Currently, only F2 is specified.