### PR TITLE
APFEL++: alpha(S), alpha(EM), and F2/FL structure functions evolution algorithms interface

### DIFF
--- a/CepGenAddOns/APFELppWrapper/AlphaEM.cpp
+++ b/CepGenAddOns/APFELppWrapper/AlphaEM.cpp
@@ -33,7 +33,9 @@ namespace cepgen {
                       steer<double>("muQEDref"),
                       steer<std::vector<double> >("quarkThresholds"),
                       steer<std::vector<double> >("leptonThresholds"),
-                      steer<int>("order")) {}
+                      steer<int>("order")) {
+        apfel::Banner();
+      }
 
       static ParametersDescription description() {
         auto desc = cepgen::Coupling::description();

--- a/CepGenAddOns/APFELppWrapper/AlphaEM.cpp
+++ b/CepGenAddOns/APFELppWrapper/AlphaEM.cpp
@@ -1,0 +1,60 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <apfel/apfelxx.h>
+
+#include <cmath>
+
+#include "CepGen/Modules/CouplingFactory.h"
+#include "CepGen/Physics/Coupling.h"
+
+namespace cepgen {
+  namespace apfelpp {
+    class AlphaEM final : public cepgen::Coupling {
+    public:
+      explicit AlphaEM(const ParametersList& params)
+          : cepgen::Coupling(params),
+            alpha_em_(steer<double>("alphaQEDref"),
+                      steer<double>("muQEDref"),
+                      steer<std::vector<double> >("quarkThresholds"),
+                      steer<std::vector<double> >("leptonThresholds"),
+                      steer<int>("order")) {}
+
+      static ParametersDescription description() {
+        auto desc = cepgen::Coupling::description();
+        desc.setDescription("APFEL++ alpha(EM) evolution algorithm");
+        desc.add<double>("alphaQEDref", 1. / 128);
+        desc.add<double>("muQEDref", 91.1876);
+        desc.add<std::vector<double> >("quarkThresholds", {0., 0., 0., M_SQRT2, 4.5, 175.});
+        desc.add<std::vector<double> >("leptonThresholds", {0., 0., 1.777});
+        desc.add<int>("order", 0)
+            .setDescription("QED evolution order")
+            .allow(0, "leading order")
+            .allow(1, "next-to-leading order");
+        return desc;
+      }
+
+      double operator()(double q) const override { return alpha_em_.Evaluate(q); }
+
+    private:
+      const apfel::AlphaQED alpha_em_;
+    };
+  }  // namespace apfelpp
+}  // namespace cepgen
+using AlphaEMAPFELpp = cepgen::apfelpp::AlphaEM;
+REGISTER_ALPHAEM_MODULE("apfelpp", AlphaEMAPFELpp);

--- a/CepGenAddOns/APFELppWrapper/AlphaS.cpp
+++ b/CepGenAddOns/APFELppWrapper/AlphaS.cpp
@@ -1,0 +1,58 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <apfel/apfelxx.h>
+
+#include "CepGen/Modules/CouplingFactory.h"
+#include "CepGen/Physics/Coupling.h"
+
+namespace cepgen {
+  namespace apfelpp {
+    class AlphaS final : public cepgen::Coupling {
+    public:
+      explicit AlphaS(const ParametersList& params)
+          : cepgen::Coupling(params),
+            alpha_s_(steer<double>("alphaSref"),
+                     steer<double>("muQCDref"),
+                     steer<std::vector<double> >("quarkThresholds"),
+                     steer<int>("order")) {}
+
+      static ParametersDescription description() {
+        auto desc = cepgen::Coupling::description();
+        desc.setDescription("APFEL++ alpha(S) evolution algorithm");
+        desc.add<double>("alphaSref", 0.118);
+        desc.add<double>("muQCDref", 91.1876);
+        desc.add<std::vector<double> >("quarkThresholds", {0., 0., 0., M_SQRT2, 4.5, 175.});
+        desc.add<int>("order", 2)
+            .setDescription("QCD perturbative evolution order")
+            .allow(0, "LO")
+            .allow(1, "NLO")
+            .allow(2, "NNLO")
+            .allow(3, "NNNLO");
+        return desc;
+      }
+
+      double operator()(double q) const override { return alpha_s_.Evaluate(q); }
+
+    private:
+      const apfel::AlphaQCD alpha_s_;
+    };
+  }  // namespace apfelpp
+}  // namespace cepgen
+using AlphaSAPFELpp = cepgen::apfelpp::AlphaS;
+REGISTER_ALPHAS_MODULE("apfelpp", AlphaSAPFELpp);

--- a/CepGenAddOns/APFELppWrapper/AlphaS.cpp
+++ b/CepGenAddOns/APFELppWrapper/AlphaS.cpp
@@ -30,7 +30,9 @@ namespace cepgen {
             alpha_s_(steer<double>("alphaSref"),
                      steer<double>("muQCDref"),
                      steer<std::vector<double> >("quarkThresholds"),
-                     steer<int>("order")) {}
+                     steer<int>("order")) {
+        apfel::Banner();
+      }
 
       static ParametersDescription description() {
         auto desc = cepgen::Coupling::description();

--- a/CepGenAddOns/APFELppWrapper/CMakeLists.txt
+++ b/CepGenAddOns/APFELppWrapper/CMakeLists.txt
@@ -1,0 +1,19 @@
+#--- searching for APFEL++
+set(apfelxx_DIRS $ENV{apfelxx_DIR} /usr /usr/local)
+find_library(apfelxx apfelxx HINTS ${apfelxx_DIRS} PATH_SUFFIXES lib)
+find_path(apfelxx_INCLUDE apfel/apfelxx.h HINTS ${apfelxx_DIRS} PATH_SUFFIXES include)
+
+if(NOT apfelxx)
+  return()
+endif()
+
+#----- build the object
+
+cepgen_build(CepGenAPFELpp SOURCES *.cpp
+    EXT_LIBS ${apfelxx}
+    EXT_HEADERS ${apfelxx_INCLUDE}
+    INSTALL_COMPONENT apfelxx)
+cpack_add_component(apfelxx
+    DISPLAY_NAME "CepGen APFEL++ wrappers library"
+    DESCRIPTION "Collection of CepGen wrappers to the APFEL++ library"
+    DEPENDS lib)

--- a/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
+++ b/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
@@ -87,6 +87,12 @@ namespace cepgen {
         desc.add("mu0", M_SQRT2).setDescription("initial scale");
         desc.add("masses", std::vector<double>{0., 0., 0., M_SQRT2, 4.5, 175.});
         desc.add("thresholds", std::vector<double>{0., 0., 0.});
+        desc.add("perturbativeOrder", 0)
+            .setDescription("perturbative order for alpha(S) evolution")
+            .allow(0, "LO")
+            .allow(1, "NLO")
+            .allow(2, "NNLO")
+            .allow(3, "NNNLO");
         desc.add("processDIS", "NC"s)
             .setDescription("process of the structure functions (NC, or CC)")
             .allow("NC", "neutral currents")

--- a/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
+++ b/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
@@ -39,16 +39,17 @@ namespace cepgen {
                          apfel::SubGrid{50, 8e-1, 3}}} {
         apfel::Banner();
         const auto thresholds = steer<std::vector<double> >("thresholds");
+        const auto mu0 = steer<double>("mu0");
         const auto perturb_order = steer<int>("perturbativeOrder");
 
-        apfel::AlphaQCD alpha_s{0.35, sqrt(2), thresholds, perturb_order};
+        apfel::AlphaQCD alpha_s{0.35, mu0, thresholds, perturb_order};
         const apfel::TabulateObject<double> alphas_tab{alpha_s, 100, 0.9, 1001, 3};
         const auto as = [&](double mu) { return alphas_tab.Evaluate(mu); };
 
         const auto fBq = [=](double q) { return apfel::ElectroWeakCharges(q, false); };  // effective charges
 
         const auto dglap_obj = apfel::InitializeDglapObjectsQCD(apfel_grid_, thresholds);
-        auto evolved_pdfs = apfel::BuildDglap(dglap_obj, apfel::LHToyPDFs, steer<double>("mu0"), perturb_order, as);
+        auto evolved_pdfs = apfel::BuildDglap(dglap_obj, apfel::LHToyPDFs, mu0, perturb_order, as);
         const apfel::TabulateObject<apfel::Set<apfel::Distribution> > tabulated_pdfs{*evolved_pdfs, 50, 1, 1000, 3};
         const auto pdfs = [&](double x, double q) { return tabulated_pdfs.EvaluateMapxQ(x, q); };
 
@@ -84,8 +85,8 @@ namespace cepgen {
       static ParametersDescription description() {
         auto desc = strfun::Parameterisation::description();
         desc.setDescription("APFEL++ DIS structure functions");
-        desc.add("mu0", M_SQRT2).setDescription("initial scale");
-        desc.add("masses", std::vector<double>{0., 0., 0., M_SQRT2, 4.5, 175.});
+        desc.add("mu0", 1.3).setDescription("initial scale");
+        desc.add("masses", std::vector<double>{0., 0., 0., 1.3, 4.75, 175.});
         desc.add("thresholds", std::vector<double>{0., 0., 0.});
         desc.add("perturbativeOrder", 0)
             .setDescription("perturbative order for alpha(S) evolution")

--- a/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
+++ b/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
@@ -1,0 +1,110 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <apfel/apfelxx.h>
+
+#include <cmath>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Modules/StructureFunctionsFactory.h"
+#include "CepGen/Physics/PDG.h"
+#include "CepGen/StructureFunctions/Parameterisation.h"
+
+using namespace std::string_literals;
+
+namespace cepgen {
+  namespace apfelpp {
+    class EvolutionStructureFunctions final : public strfun::Parameterisation {
+    public:
+      explicit EvolutionStructureFunctions(const ParametersList& params)
+          : strfun::Parameterisation(params),
+            apfel_grid_{{apfel::SubGrid{100, 1e-5, 3},
+                         apfel::SubGrid{60, 1e-1, 3},
+                         apfel::SubGrid{50, 6e-1, 3},
+                         apfel::SubGrid{50, 8e-1, 3}}},
+            proc_(steer<std::string>("processDIS")) {
+        const auto masses = steer<std::vector<double> >("masses"),
+                   thresholds = steer<std::vector<double> >("thresholds");
+        const auto perturb_order = steer<int>("perturbativeOrder");
+        const auto process_dis = steer<std::string>("processDIS");
+
+        apfel::AlphaQCD alpha_s{0.35, sqrt(2), thresholds, perturb_order};
+        const apfel::TabulateObject<double> alphas_tab{alpha_s, 100, 0.9, 1001, 3};
+        const auto as = [&](double const& mu) -> double { return alphas_tab.Evaluate(mu); };
+
+        // Effective charges
+        auto fBq = [=](double const& Q) -> std::vector<double> { return apfel::ElectroWeakCharges(Q, false); };
+
+        const auto dglap_obj = InitializeDglapObjectsQCD(apfel_grid_, thresholds);
+        auto evolved_pdfs = apfel::BuildDglap(dglap_obj, apfel::LHToyPDFs, steer<double>("mu0"), perturb_order, as);
+        const apfel::TabulateObject<apfel::Set<apfel::Distribution> > tabulated_pdfs{*evolved_pdfs, 50, 1, 1000, 3};
+        const auto pdfs = [&](double const& x, double const& Q) -> std::map<int, double> {
+          return tabulated_pdfs.EvaluateMapxQ(x, Q);
+        };
+
+        std::function<apfel::StructureFunctionObjects(double const&, std::vector<double> const&)> f2_obj, fl_obj;
+        if (process_dis == "NC") {
+          f2_obj = apfel::InitializeF2NCObjectsMassive(apfel_grid_, masses);
+          fl_obj = apfel::InitializeFLNCObjectsMassive(apfel_grid_, masses);
+        } else if (process_dis == "CC") {
+          /*const auto F2PlusCCObj = InitializeF2CCPlusObjectsZM(apfel_grid_, thresholds);
+          const auto FLPlusCCObj = InitializeFLCCPlusObjectsZM(apfel_grid_, thresholds);
+          const auto F2MinusCCObj = InitializeF2CCMinusObjectsZM(apfel_grid_, thresholds);
+          const auto FLMinusCCObj = InitializeFLCCMinusObjectsZM(apfel_grid_, thresholds);*/
+        }
+        f2_ = apfel::BuildStructureFunctions(f2_obj, pdfs, perturb_order, as, fBq);
+        fl_ = apfel::BuildStructureFunctions(fl_obj, pdfs, perturb_order, as, fBq);
+
+        // Tabulate Structure functions
+        f2_total_.reset(new apfel::TabulateObject<apfel::Distribution>{
+            [&](double const& Q) -> apfel::Distribution { return f2_.at(0).Evaluate(Q); }, 50, 1, 200, 3, thresholds});
+        fl_total_.reset(new apfel::TabulateObject<apfel::Distribution>{
+            [&](double const& Q) -> apfel::Distribution { return fl_.at(0).Evaluate(Q); }, 50, 1, 200, 3, thresholds});
+      }
+
+      static ParametersDescription description() {
+        auto desc = strfun::Parameterisation::description();
+        desc.setDescription("APFEL++ DIS structure functions");
+        desc.add("mu0", M_SQRT2).setDescription("initial scale");
+        desc.add("masses", std::vector<double>{0., 0., 0., M_SQRT2, 4.5, 175.});
+        desc.add("thresholds", std::vector<double>{0., 0., 0.});
+        desc.add("processDIS", "NC"s)
+            .setDescription("process of the structure functions (NC, or CC)")
+            .allow("NC", "neutral currents")
+            .allow("CC", "charged currents");
+        return desc;
+      }
+
+    private:
+      void eval() override {
+        setF2(f2_total_->EvaluatexQ(args_.xbj, args_.q2));
+        setFL(fl_total_->EvaluatexQ(args_.xbj, args_.q2));
+      }
+
+      const apfel::Grid apfel_grid_;  // x-space grid
+      const std::string proc_;
+
+      std::map<int, apfel::DglapObjects> dglap_obj_;
+
+      std::map<int, apfel::Observable<> > f2_, fl_;
+      std::unique_ptr<apfel::TabulateObject<apfel::Distribution> > f2_total_, fl_total_;
+    };
+  }  // namespace apfelpp
+}  // namespace cepgen
+using EvolutionStructureFunctionsAPFELpp = cepgen::apfelpp::EvolutionStructureFunctions;
+REGISTER_STRFUN("apfelppEvol", 405, EvolutionStructureFunctionsAPFELpp);

--- a/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
+++ b/CepGenAddOns/APFELppWrapper/EvolutionStructureFunctions.cpp
@@ -37,22 +37,20 @@ namespace cepgen {
                          apfel::SubGrid{60, 1e-1, 3},
                          apfel::SubGrid{50, 6e-1, 3},
                          apfel::SubGrid{50, 8e-1, 3}}} {
+        apfel::Banner();
         const auto thresholds = steer<std::vector<double> >("thresholds");
         const auto perturb_order = steer<int>("perturbativeOrder");
 
         apfel::AlphaQCD alpha_s{0.35, sqrt(2), thresholds, perturb_order};
         const apfel::TabulateObject<double> alphas_tab{alpha_s, 100, 0.9, 1001, 3};
-        const auto as = [&](double mu) -> double { return alphas_tab.Evaluate(mu); };
+        const auto as = [&](double mu) { return alphas_tab.Evaluate(mu); };
 
-        // Effective charges
-        auto fBq = [=](double q) -> std::vector<double> { return apfel::ElectroWeakCharges(q, false); };
+        const auto fBq = [=](double q) { return apfel::ElectroWeakCharges(q, false); };  // effective charges
 
         const auto dglap_obj = apfel::InitializeDglapObjectsQCD(apfel_grid_, thresholds);
         auto evolved_pdfs = apfel::BuildDglap(dglap_obj, apfel::LHToyPDFs, steer<double>("mu0"), perturb_order, as);
         const apfel::TabulateObject<apfel::Set<apfel::Distribution> > tabulated_pdfs{*evolved_pdfs, 50, 1, 1000, 3};
-        const auto pdfs = [&](double x, double q) -> std::map<int, double> {
-          return tabulated_pdfs.EvaluateMapxQ(x, q);
-        };
+        const auto pdfs = [&](double x, double q) { return tabulated_pdfs.EvaluateMapxQ(x, q); };
 
         const auto process_dis = steer<std::string>("processDIS");
         if (process_dis == "NC") {
@@ -63,9 +61,9 @@ namespace cepgen {
           auto fl = apfel::BuildStructureFunctions(fl_obj, pdfs, perturb_order, as, fBq);
           // tabulate structure functions
           f2_total_.reset(new apfel::TabulateObject<apfel::Distribution>{
-              [&](double q) -> apfel::Distribution { return f2.at(0).Evaluate(q); }, 50, 1, 200, 3, thresholds});
+              [&](double q) { return f2.at(0).Evaluate(q); }, 50, 1, 200, 3, thresholds});
           fl_total_.reset(new apfel::TabulateObject<apfel::Distribution>{
-              [&](double q) -> apfel::Distribution { return fl.at(0).Evaluate(q); }, 50, 1, 200, 3, thresholds});
+              [&](double q) { return fl.at(0).Evaluate(q); }, 50, 1, 200, 3, thresholds});
         } else if (process_dis == "CC") {
           const auto f2p_obj = apfel::InitializeF2CCPlusObjectsZM(apfel_grid_, thresholds);
           const auto f2m_obj = apfel::InitializeF2CCMinusObjectsZM(apfel_grid_, thresholds);
@@ -77,19 +75,9 @@ namespace cepgen {
           auto flm = apfel::BuildStructureFunctions(flm_obj, pdfs, perturb_order, as, fBq);
           // tabulate structure functions
           f2_total_.reset(new apfel::TabulateObject<apfel::Distribution>{
-              [&](double q) -> apfel::Distribution { return f2p.at(0).Evaluate(q) - f2m.at(0).Evaluate(q); },
-              50,
-              1,
-              200,
-              3,
-              thresholds});
+              [&](double q) { return f2p.at(0).Evaluate(q) - f2m.at(0).Evaluate(q); }, 50, 1, 200, 3, thresholds});
           fl_total_.reset(new apfel::TabulateObject<apfel::Distribution>{
-              [&](double q) -> apfel::Distribution { return flp.at(0).Evaluate(q) - flm.at(0).Evaluate(q); },
-              50,
-              1,
-              200,
-              3,
-              thresholds});
+              [&](double q) { return flp.at(0).Evaluate(q) - flm.at(0).Evaluate(q); }, 50, 1, 200, 3, thresholds});
         }
       }
 

--- a/CepGenAddOns/CMakeLists.txt
+++ b/CepGenAddOns/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(APFELWrapper)
+add_subdirectory(APFELppWrapper)
 add_subdirectory(BasesWrapper)
 add_subdirectory(BoostWrapper)
 add_subdirectory(CTMLWrapper)


### PR DESCRIPTION
This PR introduces an interface to the [APFEL++](https://github.com/vbertone/apfelxx) library for the computation of alpha(S)/alpha(EM)/F2-FM structure functions evolution.

FYI: @hamzeh-khanpour, @vbertone