### PR TITLE
Asymmetric parton virtualities constraints

### DIFF
--- a/Cards/lpair_cfg.py
+++ b/Cards/lpair_cfg.py
@@ -19,6 +19,7 @@ process = cepgen.Module('lpair',
         #--- other structure functions parameterisation are also available
         #structureFunctions = cepgen.StructureFunctions.fioreBrasse,
         #structureFunctions = cepgen.StructureFunctions.luxLike,
+        q2 = [(0., 10000.), (0., 10000.)],
     ),
     outKinematics = cepgen.Parameters(
         pt = (25.,),

--- a/CepGen/Core/RunParameters.cpp
+++ b/CepGen/Core/RunParameters.cpp
@@ -219,16 +219,20 @@ namespace cepgen {
                 StructureFunctionsFactory::get().describeParameters(beams.structureFunctions()).description())
          << "\n"
          << std::setw(wt) << "" << beams.structureFunctions().print(true) << "\n ";
+
+    // helper to print cuts list for a given category
+    const auto dump_cuts = [&os](const auto& obj) {
+      for (const auto& lim : obj.parameters().template keysOf<Limits>())
+        if (const auto& limit = obj.parameters().template get<Limits>(lim); limit.valid() && obj.description().has(lim))
+          os << std::setw(wt) << obj.description().get(lim).description() << limit << "\n";
+      for (const auto& vlim : obj.parameters().template keysOf<std::vector<Limits> >())
+        if (const auto& limit = obj.parameters().template get<std::vector<Limits> >(vlim); obj.description().has(vlim))
+          os << std::setw(wt) << obj.description().get(vlim).description() << utils::repr(limit, " and ") << "\n";
+    };
+
     os << "\n"
        << std::setfill('-') << std::setw(wb + 6) << utils::boldify(" Incoming partons ") << std::setfill(' ') << "\n\n";
     const auto& cuts = kin.cuts();
-    auto dump_cuts = [&os](const auto& obj) {
-      for (const auto& lim : obj.parameters().template keysOf<Limits>()) {
-        const auto& limit = obj.parameters().template get<Limits>(lim);
-        if (limit.valid() && obj.description().has(lim))
-          os << std::setw(wt) << obj.description().get(lim).description() << limit << "\n";
-      }
-    };
     dump_cuts(cuts.initial);
     os << "\n"
        << std::setfill('-') << std::setw(wb + 6) << utils::boldify(" Outgoing central system ") << std::setfill(' ')

--- a/CepGen/Core/SteeredObject.h
+++ b/CepGen/Core/SteeredObject.h
@@ -31,7 +31,8 @@
   __TYPE_ENUM(std::string, map_strs_)          \
   __TYPE_ENUM(Limits, map_lims_)               \
   __TYPE_ENUM(ParametersList, map_params_)     \
-  __TYPE_ENUM(std::vector<int>, map_vints_)
+  __TYPE_ENUM(std::vector<int>, map_vec_ints_) \
+  __TYPE_ENUM(std::vector<Limits>, map_vec_lims_)
 
 namespace cepgen {
   /// Base user-steerable object

--- a/CepGen/Physics/Cuts.cpp
+++ b/CepGen/Physics/Cuts.cpp
@@ -94,18 +94,23 @@ namespace cepgen {
     //------------------------------------------------------------------
 
     Initial::Initial(const ParametersList& params) : SteeredObject(params) {
-      (*this).add("q2", q2).add("qt", qt).add("phi", phi);
+      (*this).add("q21", q2_1).add("q22", q2_2).add("qt", qt).add("phi", phi);
     }
 
     void Initial::setParameters(const ParametersList& params) {
       if (params.empty())
         return;
       SteeredObject::setParameters(params);
-      if (q2.max() <= 0.) {
-        CG_WARNING("Initial:setParameters") << "Maximum parton virtuality (" << q2 << ") is invalid. "
-                                            << "It is now set to " << 1.e4 << " GeV^2.";
-        q2.max() = 1.e4;
+      if (const auto q2lim = params.get<Limits>("q2"); q2lim.valid()) {  // symmetric Q^2 cut specified
+        q2_1 = q2lim;
+        q2_2 = q2lim;
       }
+      for (auto* q2 : {&q2_1, &q2_2})
+        if (q2->max() <= 0.) {
+          CG_WARNING("Initial:setParameters") << "Maximum parton virtuality (" << *q2 << ") is invalid. "
+                                              << "It is now set to " << 1.e4 << " GeV^2.";
+          q2->max() = 1.e4;
+        }
     }
 
     bool Initial::contain(const Particles& parts, const Event*) const {
@@ -113,17 +118,22 @@ namespace cepgen {
         const auto& mom = part.momentum();
         if (!qt.contains(mom.pt()))
           return false;
-        if (!q2.contains(mom.mass2()))
+      }
+      if (parts.size() == 2) {
+        if (!q2_1.contains(parts.at(0).momentum().mass2()))
+          return false;
+        if (!q2_2.contains(parts.at(1).momentum().mass2()))
+          return false;
+        if (phi.valid() && !phi.contains(parts.at(0).momentum().deltaPhi(parts.at(1).momentum())))
           return false;
       }
-      if (parts.size() == 2 && phi.valid() && !phi.contains(parts.at(0).momentum().deltaPhi(parts.at(1).momentum())))
-        return false;
       return true;
     }
 
     ParametersDescription Initial::description() {
       auto desc = ParametersDescription();
-      desc.add<Limits>("q2", Limits{0., 1.e5}).setDescription("Virtuality (GeV^2)");
+      desc.add<Limits>("q21", Limits{0., 1.e5}).setDescription("Positive-z virtuality (GeV^2)");
+      desc.add<Limits>("q22", Limits{0., 1.e5}).setDescription("Negative-z virtuality (GeV^2)");
       desc.add<Limits>("qt", Limits{}).setDescription("Transverse virtuality (GeV)");
       desc.add<Limits>("phi", Limits{}).setDescription("Partons D(phi) (rad)");
       return desc;

--- a/CepGen/Physics/Cuts.h
+++ b/CepGen/Physics/Cuts.h
@@ -58,9 +58,10 @@ namespace cepgen {
 
       void setParameters(const ParametersList&) override;
 
-      Limits q2;   ///< parton virtuality
-      Limits qt;   ///< parton transverse virtuality
-      Limits phi;  ///< parton azimuthal angle
+      Limits q2_1;  ///< positive-z parton virtuality
+      Limits q2_2;  ///< negative-z parton virtuality
+      Limits qt;    ///< parton transverse virtuality
+      Limits phi;   ///< parton azimuthal angle
     };
 
     /// Outgoing beam remnant-like particles phase space cuts

--- a/CepGen/Physics/Cuts.h
+++ b/CepGen/Physics/Cuts.h
@@ -58,10 +58,9 @@ namespace cepgen {
 
       void setParameters(const ParametersList&) override;
 
-      Limits q2_1;  ///< positive-z parton virtuality
-      Limits q2_2;  ///< negative-z parton virtuality
-      Limits qt;    ///< parton transverse virtuality
-      Limits phi;   ///< parton azimuthal angle
+      std::vector<Limits> q2;  ///< parton virtualities
+      Limits qt;               ///< parton transverse virtuality
+      Limits phi;              ///< parton azimuthal angle
     };
 
     /// Outgoing beam remnant-like particles phase space cuts

--- a/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
+++ b/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
@@ -68,14 +68,14 @@ namespace cepgen {
 
     // register the incoming partons' virtuality
     if (log_part_virt_) {
-      const auto log_lim_q2_1 = kin.cuts().initial.q2_1.truncate(Limits{1.e-10, 5.}).compute(std::log),
-                 log_lim_q2_2 = kin.cuts().initial.q2_2.truncate(Limits{1.e-10, 5.}).compute(std::log);
+      const auto log_lim_q2_1 = kin.cuts().initial.q2.at(0).truncate(Limits{1.e-10, 5.}).compute(std::log),
+                 log_lim_q2_2 = kin.cuts().initial.q2.at(1).truncate(Limits{1.e-10, 5.}).compute(std::log);
       process()
           .defineVariable(m_t1_, proc::Process::Mapping::exponential, log_lim_q2_1, "Positive-z parton virtuality")
           .defineVariable(m_t2_, proc::Process::Mapping::exponential, log_lim_q2_2, "Negative-z parton virtuality");
     } else {
-      const auto lim_q2_1 = kin.cuts().initial.q2_1.truncate(Limits{1.e-10, 5.}),
-                 lim_q2_2 = kin.cuts().initial.q2_2.truncate(Limits{1.e-10, 5.});
+      const auto lim_q2_1 = kin.cuts().initial.q2.at(0).truncate(Limits{1.e-10, 5.}),
+                 lim_q2_2 = kin.cuts().initial.q2.at(1).truncate(Limits{1.e-10, 5.});
       process()
           .defineVariable(m_t1_, proc::Process::Mapping::linear, lim_q2_1, "Positive-z parton virtuality")
           .defineVariable(m_t2_, proc::Process::Mapping::linear, lim_q2_2, "Negative-z parton virtuality");

--- a/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
+++ b/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
@@ -68,15 +68,17 @@ namespace cepgen {
 
     // register the incoming partons' virtuality
     if (log_part_virt_) {
-      const auto log_lim_q2 = kin.cuts().initial.q2.truncate(Limits{1.e-10, 5.}).compute(std::log);
+      const auto log_lim_q2_1 = kin.cuts().initial.q2_1.truncate(Limits{1.e-10, 5.}).compute(std::log),
+                 log_lim_q2_2 = kin.cuts().initial.q2_2.truncate(Limits{1.e-10, 5.}).compute(std::log);
       process()
-          .defineVariable(m_t1_, proc::Process::Mapping::exponential, log_lim_q2, "Positive-z parton virtuality")
-          .defineVariable(m_t2_, proc::Process::Mapping::exponential, log_lim_q2, "Negative-z parton virtuality");
+          .defineVariable(m_t1_, proc::Process::Mapping::exponential, log_lim_q2_1, "Positive-z parton virtuality")
+          .defineVariable(m_t2_, proc::Process::Mapping::exponential, log_lim_q2_2, "Negative-z parton virtuality");
     } else {
-      const auto lim_q2 = kin.cuts().initial.q2.truncate(Limits{1.e-10, 5.});
+      const auto lim_q2_1 = kin.cuts().initial.q2_1.truncate(Limits{1.e-10, 5.}),
+                 lim_q2_2 = kin.cuts().initial.q2_2.truncate(Limits{1.e-10, 5.});
       process()
-          .defineVariable(m_t1_, proc::Process::Mapping::linear, lim_q2, "Positive-z parton virtuality")
-          .defineVariable(m_t2_, proc::Process::Mapping::linear, lim_q2, "Negative-z parton virtuality");
+          .defineVariable(m_t1_, proc::Process::Mapping::linear, lim_q2_1, "Positive-z parton virtuality")
+          .defineVariable(m_t2_, proc::Process::Mapping::linear, lim_q2_2, "Negative-z parton virtuality");
     }
   }
 

--- a/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
+++ b/CepGen/Process/PartonsCollinearPhaseSpaceGenerator.cpp
@@ -67,19 +67,18 @@ namespace cepgen {
     set_flux_properties(kin.incomingBeams().negative(), neg_flux_);
 
     // register the incoming partons' virtuality
-    if (log_part_virt_) {
-      const auto log_lim_q2_1 = kin.cuts().initial.q2.at(0).truncate(Limits{1.e-10, 5.}).compute(std::log),
-                 log_lim_q2_2 = kin.cuts().initial.q2.at(1).truncate(Limits{1.e-10, 5.}).compute(std::log);
+    const auto lim_q2_1 = kin.cuts().initial.q2.at(0).truncate(Limits{1.e-10, 5.}),
+               lim_q2_2 = kin.cuts().initial.q2.at(1).truncate(Limits{1.e-10, 5.});
+    if (log_part_virt_)
       process()
-          .defineVariable(m_t1_, proc::Process::Mapping::exponential, log_lim_q2_1, "Positive-z parton virtuality")
-          .defineVariable(m_t2_, proc::Process::Mapping::exponential, log_lim_q2_2, "Negative-z parton virtuality");
-    } else {
-      const auto lim_q2_1 = kin.cuts().initial.q2.at(0).truncate(Limits{1.e-10, 5.}),
-                 lim_q2_2 = kin.cuts().initial.q2.at(1).truncate(Limits{1.e-10, 5.});
+          .defineVariable(
+              m_t1_, proc::Process::Mapping::exponential, lim_q2_1.compute(std::log), "Positive-z parton virtuality")
+          .defineVariable(
+              m_t2_, proc::Process::Mapping::exponential, lim_q2_2.compute(std::log), "Negative-z parton virtuality");
+    else
       process()
           .defineVariable(m_t1_, proc::Process::Mapping::linear, lim_q2_1, "Positive-z parton virtuality")
           .defineVariable(m_t2_, proc::Process::Mapping::linear, lim_q2_2, "Negative-z parton virtuality");
-    }
   }
 
   bool PartonsCollinearPhaseSpaceGenerator::generatePartonKinematics() {

--- a/CepGen/Utils/String.cpp
+++ b/CepGen/Utils/String.cpp
@@ -161,6 +161,13 @@ namespace cepgen {
       return os.str();
     }
 
+    template <>
+    std::string toString(const Limits& lim) {
+      std::ostringstream os;
+      os << lim;
+      return os.str();
+    }
+
     std::wstring toWstring(const std::string& str) {
       typedef std::codecvt_utf8_utf16<wchar_t> convert_type;
       std::wstring_convert<convert_type, wchar_t> converter;

--- a/CepGen/Utils/String.h
+++ b/CepGen/Utils/String.h
@@ -36,6 +36,9 @@ namespace cepgen {
     inline std::string toString(const T& obj) {
       return std::to_string(obj);
     }
+    /// Specialisation of string conversion of limits
+    template <>
+    std::string toString(const Limits&);
     /// Specialisation of string conversion of parameters list
     template <>
     std::string toString(const ParametersList&);

--- a/CepGenAddOns/PythonWrapper/ConfigWriter.cpp
+++ b/CepGenAddOns/PythonWrapper/ConfigWriter.cpp
@@ -43,10 +43,16 @@ namespace cepgen {
       else if (params.has<Limits>(key)) {
         const auto lim = params.get<Limits>(key);
         return "("s + std::to_string(lim.min()) + "," + (lim.hasMax() ? std::to_string(lim.max()) : "") + ")";
+      } else if (params.has<std::vector<Limits> >(key)) {
+        std::string out{"["}, sep;
+        for (const auto& lim : params.get<std::vector<Limits> >(key))
+          out += sep + "("s + std::to_string(lim.min()) + "," + (lim.hasMax() ? std::to_string(lim.max()) : "") + ")",
+              sep = ", ";
+        return out + "]";
       } else if (params.has<std::vector<int> >(key))
-        return "["s + utils::repr(params.get<std::vector<int> >(key)) + "]";
+        return "["s + utils::repr(params.get<std::vector<int> >(key), ", ") + "]";
       else if (params.has<std::vector<double> >(key))
-        return "["s + utils::repr(params.get<std::vector<double> >(key)) + "]";
+        return "["s + utils::repr(params.get<std::vector<double> >(key), ", ") + "]";
       else if (params.has<ParametersList>(key)) {
         const auto plist = params.get<ParametersList>(key);
         return (plist.hasName() ? "cepgen.Module(\'" + plist.name() + "\'" : "cepgen.Parameters(") + repr(plist, key) +

--- a/CepGenAddOns/PythonWrapper/ObjectPtr.cpp
+++ b/CepGenAddOns/PythonWrapper/ObjectPtr.cpp
@@ -110,8 +110,7 @@ namespace cepgen {
       const bool tuple = PyTuple_Check(get()), list = PyList_Check(get());
       if (!tuple && !list)  // only accept 'tuples' and 'lists'
         return false;
-      const auto size = tuple ? PyTuple_Size(get()) : list ? PyList_Size(get()) : 0;
-      if (size == 0)
+      if (const auto size = tuple ? PyTuple_Size(get()) : list ? PyList_Size(get()) : 0; size == 0)
         return true;
       const auto first = ObjectPtr::wrap(tuple  ? PyTuple_GetItem(get(), 0) /* borrowed */
                                          : list ? PyList_GetItem(get(), 0)  /* borrowed */
@@ -245,6 +244,8 @@ namespace cepgen {
             out.set(skey, val.vector<double>());
           } else if (val.isVector<std::string>())
             out.set(skey, val.vector<std::string>());
+          else if (val.isVector<Limits>())
+            out.set(skey, val.vector<Limits>());
           else  //if (val.isVector<ParametersList>())
             out.set(skey, val.vector<ParametersList>());
         } else if (pvalue == Py_None) {
@@ -351,6 +352,7 @@ namespace cepgen {
     template ObjectPtr ObjectPtr::tupleFromVector<int>(const std::vector<int>&);
     template ObjectPtr ObjectPtr::tupleFromVector<double>(const std::vector<double>&);
     template ObjectPtr ObjectPtr::tupleFromVector<std::string>(const std::vector<std::string>&);
+    template ObjectPtr ObjectPtr::tupleFromVector<Limits>(const std::vector<Limits>&);
 
     std::ostream& operator<<(std::ostream& os, const ObjectPtr& ptr) {
       os << "PyObject{";

--- a/CepGenAddOns/PythonWrapper/PythonCardHandler.cpp
+++ b/CepGenAddOns/PythonWrapper/PythonCardHandler.cpp
@@ -99,6 +99,8 @@ namespace cepgen {
           plist_.set(attr, obj.value<ParametersList>());
         if (obj.isVector<ParametersList>())
           plist_.set(attr, obj.vector<ParametersList>());
+        if (obj.isVector<Limits>())
+          plist_.set(attr, obj.vector<Limits>());
       }
     }
     void parse() {

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -341,8 +341,8 @@ double LPAIR::pickin() {
   // definition from eq. (A.4) and (A.5) in [1]
   auto t1_max = mA2() + mX2() - 0.5 * (ss_ * sp + sl1_ * std::sqrt(rl2)) / s(),
        t1_min = (w31 * d3 + (d3 - w31) * (d3 * mA2() - w31 * mB2()) / s()) / t1_max;
-  t1_max = std::max(t1_max, -kinematics().cuts().initial.q2.max());
-  t1_min = std::min(t1_min, -kinematics().cuts().initial.q2.min());
+  t1_max = std::max(t1_max, -kinematics().cuts().initial.q2_1.max());
+  t1_min = std::min(t1_min, -kinematics().cuts().initial.q2_1.min());
   const auto t1_limits = Limits{t1_min, t1_max};
   CG_DEBUG_LOOP("LPAIR:pickin") << "t1 in range: " << t1_limits << ".";
   const auto [t1_val, t1_width] = map_expo(m_u_t1_, t1_limits);  // definition of the first photon propagator (t1 < 0)
@@ -362,8 +362,8 @@ double LPAIR::pickin() {
   // t2max, t2min definitions from eq. (A.12) and (A.13) in [1]
   auto t2_max = mB2() + mY2() - 0.5 * (r1 * r2 + std::sqrt(rl4)) / s2_,
        t2_min = (w52 * d4 + (d4 - w52) * (d4 * mB2() - w52 * t1()) / s2_) / t2_max;
-  t2_max = std::max(t2_max, -kinematics().cuts().initial.q2.max());
-  t2_min = std::min(t2_min, -kinematics().cuts().initial.q2.min());
+  t2_max = std::max(t2_max, -kinematics().cuts().initial.q2_2.max());
+  t2_min = std::min(t2_min, -kinematics().cuts().initial.q2_2.min());
   const auto t2_limits = Limits{t2_min, t2_max};
   CG_DEBUG_LOOP("LPAIR:pickin") << "t2 in range: " << t2_limits << ".";
   const auto [t2_val, t2_width] = map_expo(m_u_t2_, t2_limits);  // definition of the second photon propagator (t2 < 0)

--- a/CepGenProcesses/LPAIR.cpp
+++ b/CepGenProcesses/LPAIR.cpp
@@ -341,8 +341,8 @@ double LPAIR::pickin() {
   // definition from eq. (A.4) and (A.5) in [1]
   auto t1_max = mA2() + mX2() - 0.5 * (ss_ * sp + sl1_ * std::sqrt(rl2)) / s(),
        t1_min = (w31 * d3 + (d3 - w31) * (d3 * mA2() - w31 * mB2()) / s()) / t1_max;
-  t1_max = std::max(t1_max, -kinematics().cuts().initial.q2_1.max());
-  t1_min = std::min(t1_min, -kinematics().cuts().initial.q2_1.min());
+  t1_max = std::max(t1_max, -kinematics().cuts().initial.q2.at(0).max());
+  t1_min = std::min(t1_min, -kinematics().cuts().initial.q2.at(0).min());
   const auto t1_limits = Limits{t1_min, t1_max};
   CG_DEBUG_LOOP("LPAIR:pickin") << "t1 in range: " << t1_limits << ".";
   const auto [t1_val, t1_width] = map_expo(m_u_t1_, t1_limits);  // definition of the first photon propagator (t1 < 0)
@@ -362,8 +362,8 @@ double LPAIR::pickin() {
   // t2max, t2min definitions from eq. (A.12) and (A.13) in [1]
   auto t2_max = mB2() + mY2() - 0.5 * (r1 * r2 + std::sqrt(rl4)) / s2_,
        t2_min = (w52 * d4 + (d4 - w52) * (d4 * mB2() - w52 * t1()) / s2_) / t2_max;
-  t2_max = std::max(t2_max, -kinematics().cuts().initial.q2_2.max());
-  t2_min = std::min(t2_min, -kinematics().cuts().initial.q2_2.min());
+  t2_max = std::max(t2_max, -kinematics().cuts().initial.q2.at(1).max());
+  t2_min = std::min(t2_min, -kinematics().cuts().initial.q2.at(1).min());
   const auto t2_limits = Limits{t2_min, t2_max};
   CG_DEBUG_LOOP("LPAIR:pickin") << "t2 in range: " << t2_limits << ".";
   const auto [t2_val, t2_width] = map_expo(m_u_t2_, t2_limits);  // definition of the second photon propagator (t2 < 0)


### PR DESCRIPTION
This PR transforms the `q2` incoming partons cut from a plain `cepgen::Limit` object to a (2-dimensional) vector of limits.
It allows to define asymmetric cuts for both partons (e.g. in single-dissociative pp, or in asymmetric ep collisions)

Backward-compatibility with circulating steering cards is ensured through the trivial (symmetric) transformation:

`cepgen::Limits{a, b}` → `std::vector<cepgen::Limits>{{a, b}, {a, b}}`

FYI: @hamzeh-khanpour 