### PR TITLE
Core: Improved Fortran interface

### DIFF
--- a/CepGen/Core/FortranInterface.cpp
+++ b/CepGen/Core/FortranInterface.cpp
@@ -30,6 +30,8 @@
 
 static std::unordered_map<int, std::unique_ptr<cepgen::strfun::Parameterisation> > kBuiltStrFunsParameterisations;
 static std::unordered_map<int, std::unique_ptr<cepgen::KTFlux> > kBuiltKtFluxParameterisations;
+static std::unordered_map<std::string, std::unique_ptr<cepgen::Coupling> > kBuiltAlphaSParameterisations,
+    kBuiltAlphaEMParameterisations;
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,22 +124,18 @@ void cepgen_error_(char* str, int size) { CG_ERROR("fortran_process") << std::st
 
 void cepgen_fatal_(char* str, int size) { throw CG_FATAL("fortran_process") << std::string(str, size); }
 
-double cepgen_alphas_(double& q) {
-  static std::unique_ptr<cepgen::Coupling> kAlphaSPtr;
-  if (!kAlphaSPtr) {
-    CG_INFO("fortran_process") << "Initialisation of the alpha(S) evolution algorithm.";
-    kAlphaSPtr = cepgen::AlphaSFactory::get().build("pegasus");
-  }
-  return (*kAlphaSPtr)(q);
+double cepgen_alphas_(char* str, double& q, int size) {
+  const auto name = std::string(str, size);
+  if (kBuiltAlphaSParameterisations.count(name) == 0)
+    kBuiltAlphaSParameterisations[name] = cepgen::AlphaSFactory::get().build(name);
+  return kBuiltAlphaSParameterisations.at(name)->operator()(q);
 }
 
-double cepgen_alphaem_(double& q) {
-  static std::unique_ptr<cepgen::Coupling> kAlphaEMPtr;
-  if (!kAlphaEMPtr) {
-    CG_INFO("fortran_process") << "Initialisation of the alpha(EM) evolution algorithm.";
-    kAlphaEMPtr = cepgen::AlphaEMFactory::get().build("fixed");
-  }
-  return (*kAlphaEMPtr)(q);
+double cepgen_alphaem_(char* str, double& q, int size) {
+  const auto name = std::string(str, size);
+  if (kBuiltAlphaEMParameterisations.count(name) == 0)
+    kBuiltAlphaEMParameterisations[name] = cepgen::AlphaEMFactory::get().build(name);
+  return kBuiltAlphaEMParameterisations.at(name)->operator()(q);
 }
 
 #ifdef __cplusplus

--- a/CepGen/Core/FortranInterface.cpp
+++ b/CepGen/Core/FortranInterface.cpp
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2013-2023  Laurent Forthomme
+ *  Copyright (C) 2017-2024  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -28,13 +28,17 @@
 #include "CepGen/Physics/PDG.h"
 #include "CepGen/StructureFunctions/Parameterisation.h"
 
+static std::unordered_map<int, std::unique_ptr<cepgen::strfun::Parameterisation> > kBuiltStrFunsParameterisations;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 /// Expose structure functions calculators to Fortran
 void cepgen_structure_functions_(int& sfmode, double& xbj, double& q2, double& f2, double& fl) {
   using namespace cepgen;
-  static auto sf = StructureFunctionsFactory::get().build(sfmode);
+  if (kBuiltStrFunsParameterisations.count(sfmode) == 0)
+    kBuiltStrFunsParameterisations[sfmode] = StructureFunctionsFactory::get().build(sfmode);
+  const auto& sf = kBuiltStrFunsParameterisations.at(sfmode);
   f2 = sf->F2(xbj, q2);
   fl = sf->FL(xbj, q2);
 }

--- a/CepGen/KTFluxes/ElasticKTFluxes.cpp
+++ b/CepGen/KTFluxes/ElasticKTFluxes.cpp
@@ -128,7 +128,7 @@ namespace cepgen {
   };
 }  // namespace cepgen
 
-REGISTER_KT_FLUX("Elastic", ElasticNucleonKTFlux);
-REGISTER_KT_FLUX("BudnevElastic", BudnevElasticNucleonKTFlux);
-REGISTER_KT_FLUX("BudnevElasticLepton", BudnevElasticLeptonKTFlux);
-REGISTER_KT_FLUX("ElasticHeavyIon", ElasticHeavyIonKTFlux);
+REGISTER_KT_FLUX("Elastic", 0, ElasticNucleonKTFlux);
+REGISTER_KT_FLUX("BudnevElastic", 10, BudnevElasticNucleonKTFlux);
+REGISTER_KT_FLUX("BudnevElasticLepton", 12, BudnevElasticLeptonKTFlux);
+REGISTER_KT_FLUX("ElasticHeavyIon", 100, ElasticHeavyIonKTFlux);

--- a/CepGen/KTFluxes/InelasticKTFluxes.cpp
+++ b/CepGen/KTFluxes/InelasticKTFluxes.cpp
@@ -87,5 +87,5 @@ namespace cepgen {
   };
 }  // namespace cepgen
 
-REGISTER_KT_FLUX("Inelastic", InelasticNucleonKTFlux);
-REGISTER_KT_FLUX("BudnevInelastic", BudnevInelasticNucleonKTFlux);
+REGISTER_KT_FLUX("Inelastic", 1, InelasticNucleonKTFlux);
+REGISTER_KT_FLUX("BudnevInelastic", 11, BudnevInelasticNucleonKTFlux);

--- a/CepGen/KTFluxes/KMRGluonKTFlux.cpp
+++ b/CepGen/KTFluxes/KMRGluonKTFlux.cpp
@@ -40,4 +40,4 @@ namespace cepgen {
   };
 }  // namespace cepgen
 
-REGISTER_KT_FLUX("KMR", KMRGluonKTFlux);
+REGISTER_KT_FLUX("KMR", 20, KMRGluonKTFlux);

--- a/CepGen/KTFluxes/KleinElasticHeavyIonKTFlux.cpp
+++ b/CepGen/KTFluxes/KleinElasticHeavyIonKTFlux.cpp
@@ -70,4 +70,4 @@ namespace cepgen {
   };
 }  // namespace cepgen
 
-REGISTER_KT_FLUX("KleinElasticHI", KleinElasticHeavyIonKTFlux);
+REGISTER_KT_FLUX("KleinElasticHI", 101, KleinElasticHeavyIonKTFlux);

--- a/CepGen/Modules/PartonFluxFactory.h
+++ b/CepGen/Modules/PartonFluxFactory.h
@@ -31,13 +31,13 @@
   }                                                                               \
   static_assert(true, "")
 /// Add a generic KT-factorised flux evaluator builder definition
-#define REGISTER_KT_FLUX(name, obj)                                        \
-  namespace cepgen {                                                       \
-    struct BUILDERNM(obj) {                                                \
-      BUILDERNM(obj)() { KTFluxFactory::get().registerModule<obj>(name); } \
-    };                                                                     \
-    static const BUILDERNM(obj) gKTFlux##obj;                              \
-  }                                                                        \
+#define REGISTER_KT_FLUX(name, id, obj)                                                       \
+  namespace cepgen {                                                                          \
+    struct BUILDERNM(obj) {                                                                   \
+      BUILDERNM(obj)() { KTFluxFactory::get().addIndex(id, name).registerModule<obj>(name); } \
+    };                                                                                        \
+    static const BUILDERNM(obj) gKTFlux##obj;                                                 \
+  }                                                                                           \
   static_assert(true, "")
 
 namespace cepgen {

--- a/test/physics/fortran_couplings.f
+++ b/test/physics/fortran_couplings.f
@@ -1,0 +1,19 @@
+      program main
+      implicit none
+      integer i, niter
+      double precision min_q, max_q, q
+      double precision CepGen_AlphaEM, CepGen_AlphaS
+
+      call CepGen_init
+
+      min_q = 1.0d0
+      max_q = 1.0d2
+      niter = 101
+
+      do i = 1, niter
+        q = min_q + (max_q - min_q) * (i - 1) / (niter - 1)
+        print *, q, CepGen_AlphaEM('burkhardt', q),
+     &              CepGen_AlphaS('pegasus', q)
+      enddo
+      call exit(0)
+      end

--- a/test/physics/fortran_strfuns.f
+++ b/test/physics/fortran_strfuns.f
@@ -1,15 +1,12 @@
       program main
-
       implicit none
-      integer i, niter, nsf
-      double precision f2, fl
+      integer i, niter
+      double precision f2_ll, fl_ll, f2_sy, fl_sy
       double precision xbj, min_xbj, max_xbj
       double precision q2
 
       call CepGen_init
 
-c      nsf = 204 !GD11p
-      nsf = 301 !LUXlike
       q2 = 10.225
       min_xbj = 1.0d - 3
       max_xbj = 1.0
@@ -17,8 +14,9 @@ c      nsf = 204 !GD11p
 
       do i = 1, niter
         xbj = min_xbj + (max_xbj - min_xbj) * (i - 1) / (niter - 1)
-        call CepGen_Structure_Functions(nsf, xbj, q2, f2, fl)
-        print *, q2, xbj, f2, fl
+        call CepGen_Structure_Functions(301, xbj, q2, f2_ll, fl_ll)
+        call CepGen_Structure_Functions(11, xbj, q2, f2_sy, fl_sy)
+        print *, q2, xbj, f2_ll, fl_ll, f2_sy, fl_sy
       enddo
       call exit(0)
       end


### PR DESCRIPTION
This PR improves the API for CepGen-Fortran subroutines and functions calls.

It gives a better control to the modelling requested for structure functions, strong, and electromagnetic couplings parameterisations, and allows for multiple concurrent modellings to be called in parallel.

For instance, the following code can be used for alpha(EM)/alpha(S) comparison at a given q:

```fortran
      program main
      implicit none
      integer i, niter
      double precision min_q, max_q, q
      double precision CepGen_AlphaEM, CepGen_AlphaS

      call CepGen_init

      min_q = 1.0d0
      max_q = 1.0d2
      niter = 101
      do i = 1, niter
        q = min_q + (max_q - min_q) * (i - 1) / (niter - 1)
        print *, q, CepGen_AlphaEM('burkhardt', q),
     &              CepGen_AlphaS('pegasus', q)
      enddo
      end program
```

Equivalently, the LUXlike (CepGen index 301, as shown [here](https://cepgen.hepforge.org/raw-modules#strfun)) and Suri-Yennie (index 11) F<sub>2,L</sub> parameterisations can be compared along x<sub>Bj</sub> for a given Q<sup>2</sup> with:

```fortran
      program main
      implicit none
      integer i, niter
      double precision f2_ll, fl_ll, f2_sy, fl_sy
      double precision xbj, min_xbj, max_xbj
      double precision q2

      call CepGen_init

      q2 = 10.225
      min_xbj = 1.0d - 3
      max_xbj = 1.0
      niter = 101
      do i = 1, niter
        xbj = min_xbj + (max_xbj - min_xbj) * (i - 1) / (niter - 1)
        call CepGen_Structure_Functions(301, xbj, q2, f2_ll, fl_ll)
        call CepGen_Structure_Functions(11, xbj, q2, f2_sy, fl_sy)
        print *, q2, xbj, f2_ll, fl_ll, f2_sy, fl_sy
      enddo
      end program
```

The technique paves the way for future Fortran interfacing developments (analytical, or MC integration, collinear fluxes, nuclear form factors, ...)

FYI: @wschafer, @MartaLuszczak, Barbara