### PR TITLE
Add published MISER reference

### DIFF
--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -13,8 +13,11 @@
 @article{Press:1989vk,
       author         = "Press, William H. and Farrar, Glennys R.",
       title          = "Recursive stratified sampling for multidimensional {Monte Carlo} integration",
-      journal        = "Submitted to: Comp.in Phys.",
+      journal        = "Comput. Phys.",
+      volume         = "4",
       year           = "1989",
+      pages          = "190--195",
+      doi            = "10.1063/1.4822899",
       reportNumber   = "CFA-3010",
       SLACcitation   = "%%CITATION = CFA-3010;%%"
 }


### PR DESCRIPTION
Hi, @forthommel . There seems to be a published article version of this reference in src/Integration/MISERIntegrator.cpp , or are you referring to some pre-print specific text left out in the publication?