### PR TITLE
CI: access to LCG software stacks on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: 'CMake configuration'
       run: |
-        source source-lxplus.sh
+        source /cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/setup.sh
         git config --global --add safe.directory /Package
         cmake -GNinja -B ${{ env.CEPGEN_PATH }} \
               -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       options: -v ${{ github.workspace }}:/Package
     steps:
     - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: seanmiddleditch/gha-setup-ninja@master
 
     - name: 'MadGraph fetch'
@@ -35,6 +36,7 @@ jobs:
 
     - name: 'CMake configuration'
       run: |
+        source source-lxplus.sh
         git config --global --add safe.directory /Package
         cmake -GNinja -B ${{ env.CEPGEN_PATH }} \
               -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \


### PR DESCRIPTION
This PR allows to access the LCG software stack on CERN's cvmfs. This fortunately allows to increase the number of pre-supported (and documented) add-on packages.