### PR TITLE
mg5_aMC: electron-parton matrix elements

### DIFF
--- a/Cards/mg5amcnlo/aatautau_ep_coll_cfg.py
+++ b/Cards/mg5amcnlo/aatautau_ep_coll_cfg.py
@@ -1,0 +1,32 @@
+import Config.Core as cepgen
+import Config.collinearProcess_cfi as coll
+from Config.generator_cfi import generator
+from FormFactors.standardDipole_cfi import standardDipole
+from FormFactors.pointLikeFermion_cfi import pointLikeFermion
+
+#--- process definition
+process = coll.process.clone('mg5_aMC:eh',
+    processParameters = cepgen.Parameters(
+        process = 'a e- > ta+ ta- e- / h z e-',
+        model = 'sm-full',
+        mode = cepgen.ProcessMode.ElasticElastic,
+        #kinematicsGenerator = cepgen.Module('kt_single:2to4'),
+        kinematicsGenerator = cepgen.Module('kt:2to4'),
+    ),
+    inKinematics = cepgen.Parameters(
+        pdgIds = (2212, 11),
+        formFactors = [standardDipole, pointLikeFermion],
+        pz = (7000., 50.),
+        structureFunctions = cepgen.StructureFunctions.luxLike,
+    ),
+    outKinematics = coll.process.outKinematics.clone(
+        q2 = (0., 10.),
+        #eta = (-2.5, 2.5),
+        mx = (1.07, 1000.),
+        pt = (2.5,),
+    ),
+)
+
+generator.numEvents = 10000
+dump = cepgen.Module('dump', printEvery = generator.printEvery)
+output = cepgen.Sequence(dump)

--- a/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
+++ b/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
@@ -1,0 +1,35 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2025  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CepGen/Process/FactorisedProcess.h"
+#include "CepGenMadGraph/Process.h"
+
+namespace cepgen::mg5amc {
+  class ProcessBuilder : public proc::FactorisedProcess {
+  public:
+    explicit ProcessBuilder(const ParametersList& params, bool load_library = true);
+
+    static ParametersDescription description();
+
+    void addEventContent() override;
+
+  protected:
+    void loadMG5Library() const;
+    std::unique_ptr<mg5amc::Process> mg5_proc_;
+  };
+}  // namespace cepgen::mg5amc

--- a/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
+++ b/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
@@ -26,8 +26,6 @@ namespace cepgen::mg5amc {
 
     static ParametersDescription description();
 
-    void addEventContent() override;
-
   protected:
     void loadMG5Library() const;
     void prepareSteeringCard() const;

--- a/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
+++ b/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
@@ -31,7 +31,9 @@ namespace cepgen::mg5amc {
   protected:
     void loadMG5Library() const;
     void prepareSteeringCard() const;
+    mg5amc::Process& process() const;
 
+  private:
     std::unique_ptr<mg5amc::Process> mg5_proc_;
   };
 }  // namespace cepgen::mg5amc

--- a/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
+++ b/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
@@ -23,15 +23,17 @@ namespace cepgen::mg5amc {
   class ProcessBuilder : public proc::FactorisedProcess {
   public:
     explicit ProcessBuilder(const ParametersList& params, bool load_library = true);
+    ~ProcessBuilder() override;
 
     static ParametersDescription description();
 
   protected:
-    void loadMG5Library() const;
+    void loadMG5Library();
     void prepareSteeringCard() const;
     mg5amc::Process& process() const;
 
   private:
+    std::string library_filename_;
     std::unique_ptr<mg5amc::Process> mg5_proc_;
   };
 }  // namespace cepgen::mg5amc

--- a/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
+++ b/addons/MadGraphWrapper/CepGenMadGraph/ProcessBuilder.h
@@ -30,6 +30,8 @@ namespace cepgen::mg5amc {
 
   protected:
     void loadMG5Library() const;
+    void prepareSteeringCard() const;
+
     std::unique_ptr<mg5amc::Process> mg5_proc_;
   };
 }  // namespace cepgen::mg5amc

--- a/addons/MadGraphWrapper/src/ElectronPartonProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ElectronPartonProcessBuilder.cpp
@@ -1,0 +1,182 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2025  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fstream>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Event/Event.h"
+#include "CepGen/Generator.h"
+#include "CepGen/Modules/ProcessFactory.h"
+#include "CepGen/Physics/PDG.h"
+#include "CepGen/Process/FactorisedProcess.h"
+#include "CepGen/Utils/AbortHandler.h"
+#include "CepGen/Utils/Math.h"
+#include "CepGen/Utils/RandomGenerator.h"
+#include "CepGenMadGraph/Interface.h"
+#include "CepGenMadGraph/Process.h"
+#include "CepGenMadGraph/ProcessFactory.h"
+#include "CepGenMadGraph/Utils.h"
+
+using namespace cepgen;
+using namespace std::string_literals;
+
+namespace cepgen::mg5amc {
+  class ElectronPartonProcessBuilder : public proc::FactorisedProcess {
+  public:
+    explicit ElectronPartonProcessBuilder(const ParametersList& params, bool load_library = true)
+        : FactorisedProcess(params, {}) {
+      if (load_library)
+        loadMG5Library();
+      CG_DEBUG("ElectronPartonProcessBuilder")
+          << "List of MadGraph process registered in the runtime database: " << ProcessFactory::get().modules() << ".";
+      // once MadGraph process library is loaded into runtime environment, can define its wrapper object
+      mg5_proc_ = ProcessFactory::get().build(normalise(steer<std::string>("process")));
+      if (mg5_proc_->centralSystem().empty())
+        throw CG_FATAL("ElectronPartonProcessBuilder")
+            << "Failed to retrieve produced particles system from MadGraph process:\n"
+            << mg5_proc_->description().validate(mg5_proc_->parameters()) << ".";
+      auto central_system = mg5_proc_->centralSystem();
+      if (std::abs(*central_system.begin()) == PDG::electron) {
+        e_pdg_ = *central_system.begin();
+        mode_ = Mode::electron_parton;
+        central_system.erase(central_system.begin());
+      } else if (std::abs(*central_system.rbegin()) == PDG::electron) {
+        e_pdg_ = *central_system.rbegin();
+        mode_ = Mode::parton_electron;
+        central_system.pop_back();
+      } else
+        throw CG_FATAL("ElectronPartonProcessBuilder")
+            << "No electron/positron found in mg5_aMC process particles list.";
+      phase_space_generator_->setCentral(central_system);
+    }
+
+    proc::ProcessPtr clone() const override {
+      return std::make_unique<ElectronPartonProcessBuilder>(parameters(), false);
+    }
+
+    void addEventContent() override {
+      const auto central_system = phase_space_generator_->central();
+      Process::setEventContent(
+          {{Particle::Role::IncomingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
+           {Particle::Role::IncomingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
+           {Particle::Role::OutgoingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
+           {Particle::Role::OutgoingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
+           {Particle::Role::CentralSystem, spdgids_t(central_system.begin(), central_system.end())}});
+    }
+
+    static ParametersDescription description() {
+      auto desc = FactorisedProcess::description();
+      desc.setDescription("MadGraph_aMC electron-parton process builder");
+      desc.add("lib", ""s).setDescription("Precompiled library for this process definition");
+      desc.add("parametersCard", "param_card.dat"s).setDescription("Runtime MadGraph parameters card");
+      desc += Interface::description();
+      return desc;
+    }
+
+    void prepareFactorisedPhaseSpace() override {
+      if (const auto psgen_partons = phase_space_generator_->partons();
+          (mode_ == Mode::parton_electron &&
+           *mg5_proc_->intermediatePartons().begin() != static_cast<int>(psgen_partons.at(0))) ||
+          (mode_ == Mode::electron_parton &&
+           *mg5_proc_->intermediatePartons().rbegin() != static_cast<int>(psgen_partons.at(1))))
+        throw CG_FATAL("ElectronPartonProcessBuilder")
+            << "MadGraph unpacked process incoming state (" << mg5_proc_->intermediatePartons()
+            << ") is incompatible with user-steered incoming fluxes particles (" << phase_space_generator_->partons()
+            << ").";
+      if (const auto params_card = steer<std::string>("parametersCard"); !params_card.empty()) {
+        CG_INFO("ElectronPartonProcessBuilder")
+            << "Preparing process kinematics for card at \"" << params_card << "\".";
+        const auto unsteered_pcard = Interface::extractParamCardParameters(utils::readFile(params_card));
+        CG_DEBUG("ElectronPartonProcessBuilder") << "Unsteered parameters card:\n" << unsteered_pcard;
+        if (const auto mod_params = steer<ParametersList>("modelParameters"); !mod_params.empty()) {
+          const auto steered_pcard = unsteered_pcard.steer(mod_params);
+          CG_DEBUG("ElectronPartonProcessBuilder") << "User-steered parameters:" << mod_params << "\n"
+                                                   << "Steered parameters card:\n"
+                                                   << steered_pcard;
+          std::ofstream params_card_steered(params_card);
+          params_card_steered << Interface::generateParamCard(steered_pcard);
+          params_card_steered.close();
+        }
+        mg5_proc_->initialise(params_card);
+      }
+    }
+    double computeFactorisedMatrixElement() override {
+      if (!mg5_proc_)
+        throw CG_FATAL("ElectronPartonProcessBuilder:eval") << "Process not properly linked!";
+      if (!kinematics().cuts().initial.contain(event()(Particle::Role::Parton1)) ||
+          !kinematics().cuts().initial.contain(event()(Particle::Role::Parton2)))
+        return 0.;
+      if (!kinematics().cuts().central.contain(event()(Particle::Role::CentralSystem)))
+        return 0.;
+      pX() = (pA() - q1()).setMass2(mX2());
+      pY() = (pB() - q2()).setMass2(mY2());
+      CG_DEBUG_LOOP("ElectronPartonProcessBuilder:eval")
+          << "Particles content:\n"
+          << "incoming: " << q1() << " (m=" << q1().mass() << "), " << q2() << " (m=" << q2().mass() << ")\n"
+          << "outgoing: " << pc(0) << " (m=" << pc(0).mass() << "), " << pc(1) << " (m=" << pc(1).mass() << ").";
+      if (mode_ == Mode::electron_parton) {
+        size_t i = 0;
+        mg5_proc_->setMomentum(i++, pA());  // first "parton" is beam electron
+        mg5_proc_->setMomentum(i++, q2());  // second "parton" is parton-from-hadron
+        mg5_proc_->setMomentum(i++, pX());
+        for (size_t j = 0; j < phase_space_generator_->central().size(); ++j)
+          mg5_proc_->setMomentum(i++, pc(j));  // outgoing central particles
+      } else if (mode_ == Mode::parton_electron) {
+        size_t i = 0;
+        mg5_proc_->setMomentum(i++, q1());  // first "parton" is parton-from-hadron
+        mg5_proc_->setMomentum(i++, pB());  // second "parton" is beam electron
+        for (size_t j = 0; j < phase_space_generator_->central().size(); ++j)
+          mg5_proc_->setMomentum(i++, pc(j));  // outgoing central particles
+        mg5_proc_->setMomentum(i++, pY());
+      } else
+        throw CG_FATAL("ElectronPartonProcessBuilder:eval") << "Invalid beams mode: " << mode_ << ".";
+      if (const auto weight = mg5_proc_->eval(); utils::positive(weight))
+        return weight * std::pow(shat(), -2);
+      return 0.;
+    }
+
+  private:
+    void loadMG5Library() const {
+      utils::AbortHandler();
+      try {
+        if (const auto& lib_file = steer<std::string>("lib"); !lib_file.empty())  // user-provided library file
+          loadLibrary(lib_file);
+        else {  // library has to be generated from mg5_aMC directives
+          const Interface interface(params_);
+          loadLibrary(interface.run());
+        }
+      } catch (const utils::RunAbortedException&) {
+        CG_FATAL("ElectronPartonProcessBuilder") << "MadGraph_aMC process generation aborted.";
+      }
+    }
+    std::unique_ptr<mg5amc::Process> mg5_proc_;
+    spdgid_t e_pdg_{11};
+    enum struct Mode { electron_parton, parton_electron } mode_{Mode::electron_parton};
+    friend std::ostream& operator<<(std::ostream& os, const Mode& mode) {
+      switch (mode) {
+        case Mode::electron_parton:
+          return os << "electron-parton";
+        case Mode::parton_electron:
+          return os << "parton-electron";
+      }
+      return os << "invalid";
+    }
+  };
+}  // namespace cepgen::mg5amc
+using MadGraphElectronPartonProcessBuilder = cepgen::mg5amc::ElectronPartonProcessBuilder;
+REGISTER_PROCESS("mg5_aMC:eh", MadGraphElectronPartonProcessBuilder);

--- a/addons/MadGraphWrapper/src/ElectronPartonProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ElectronPartonProcessBuilder.cpp
@@ -43,7 +43,7 @@ namespace cepgen::mg5amc {
       } else
         throw CG_FATAL("ElectronPartonProcessBuilder")
             << "No electron/positron found in mg5_aMC process particles list.";
-      phase_space_generator_->setCentral(central_system);  // electron/positron stripped off central system
+      setCentral(central_system);  // electron/positron stripped off central system
     }
 
     proc::ProcessPtr clone() const override {

--- a/addons/MadGraphWrapper/src/ElectronPartonProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ElectronPartonProcessBuilder.cpp
@@ -33,17 +33,17 @@ namespace cepgen::mg5amc {
         : ProcessBuilder(params, load_library) {
       auto central_system = process().centralSystem();
       if (std::abs(*central_system.begin()) == PDG::electron) {
-        e_pdg_ = *central_system.begin();
         mode_ = Mode::electron_parton;
-        central_system.erase(central_system.begin());
+        e_pdg_ = *central_system.begin();              // electron, or positron?
+        central_system.erase(central_system.begin());  // first particle is lepton
       } else if (std::abs(*central_system.rbegin()) == PDG::electron) {
-        e_pdg_ = *central_system.rbegin();
         mode_ = Mode::parton_electron;
-        central_system.pop_back();
+        e_pdg_ = *central_system.rbegin();  // electron, or positron?
+        central_system.pop_back();          // last particle is lepton
       } else
         throw CG_FATAL("ElectronPartonProcessBuilder")
             << "No electron/positron found in mg5_aMC process particles list.";
-      phase_space_generator_->setCentral(central_system);
+      phase_space_generator_->setCentral(central_system);  // electron/positron stripped off central system
     }
 
     proc::ProcessPtr clone() const override {
@@ -57,7 +57,7 @@ namespace cepgen::mg5amc {
     }
 
     void prepareFactorisedPhaseSpace() override {
-      if (const auto psgen_partons = phase_space_generator_->partons();
+      if (const auto psgen_partons = phase_space_generator_->partons();  // ensure parton system is compatible
           (mode_ == Mode::parton_electron &&
            *process().intermediatePartons().begin() != static_cast<int>(psgen_partons.at(0))) ||
           (mode_ == Mode::electron_parton &&

--- a/addons/MadGraphWrapper/src/GeneralProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/GeneralProcessBuilder.cpp
@@ -31,22 +31,20 @@ namespace cepgen::mg5amc {
   public:
     explicit GeneralProcessBuilder(const ParametersList& params, bool load_library = true)
         : ProcessBuilder(params, load_library) {
-      setCentral(mg5_proc_->centralSystem());
+      setCentral(process().centralSystem());
     }
 
     proc::ProcessPtr clone() const override { return std::make_unique<GeneralProcessBuilder>(parameters(), false); }
 
     void prepareFactorisedPhaseSpace() override {
       if (const auto psgen_partons = phase_space_generator_->partons();
-          mg5_proc_->intermediatePartons() != psgen_partons)
+          process().intermediatePartons() != psgen_partons)
         throw CG_FATAL("mg5amc:GeneralProcessBuilder")
-            << "MadGraph unpacked process incoming state (" << mg5_proc_->intermediatePartons() << ") "
+            << "MadGraph unpacked process incoming state (" << process().intermediatePartons() << ") "
             << "is incompatible with user-steered incoming fluxes particles (" << psgen_partons << ").";
       prepareSteeringCard();
     }
     double computeFactorisedMatrixElement() override {
-      if (!mg5_proc_)
-        CG_FATAL("mg5amc:GeneralProcessBuilder:eval") << "Process not properly linked!";
       if (!kinematics().cuts().initial.contain(event()(Particle::Role::Parton1)) ||
           !kinematics().cuts().initial.contain(event()(Particle::Role::Parton2)))
         return 0.;
@@ -57,11 +55,11 @@ namespace cepgen::mg5amc {
           << "Particles content:\n"
           << "incoming: " << q1() << " (m=" << q1().mass() << "), " << q2() << " (m=" << q2().mass() << ")\n"
           << "outgoing: " << pc(0) << " (m=" << pc(0).mass() << "), " << pc(1) << " (m=" << pc(1).mass() << ").";
-      mg5_proc_->setMomentum(0, q1());   // first incoming parton
-      mg5_proc_->setMomentum(1, q2());   // second incoming parton
-      mg5_proc_->setMomentum(2, pc(0));  // first outgoing central particle
-      mg5_proc_->setMomentum(3, pc(1));  // second outgoing central particle
-      if (const auto weight = mg5_proc_->eval(); utils::positive(weight))
+      process().setMomentum(0, q1());   // first incoming parton
+      process().setMomentum(1, q2());   // second incoming parton
+      process().setMomentum(2, pc(0));  // first outgoing central particle
+      process().setMomentum(3, pc(1));  // second outgoing central particle
+      if (const auto weight = process().eval(); utils::positive(weight))
         return weight * std::pow(shat(), -2);
       return 0.;
     }

--- a/addons/MadGraphWrapper/src/GeneralProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/GeneralProcessBuilder.cpp
@@ -1,0 +1,92 @@
+/*
+ *  CepGen: a central exclusive processes event generator
+ *  Copyright (C) 2020-2025  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fstream>
+
+#include "CepGen/Core/Exception.h"
+#include "CepGen/Event/Event.h"
+#include "CepGen/Generator.h"
+#include "CepGen/Modules/ProcessFactory.h"
+#include "CepGen/Process/FactorisedProcess.h"
+#include "CepGen/Utils/Math.h"
+#include "CepGen/Utils/RandomGenerator.h"
+#include "CepGenMadGraph/Interface.h"
+#include "CepGenMadGraph/Process.h"
+#include "CepGenMadGraph/ProcessBuilder.h"
+
+using namespace cepgen;
+using namespace std::string_literals;
+
+namespace cepgen::mg5amc {
+  class GeneralProcessBuilder final : public ProcessBuilder {
+  public:
+    explicit GeneralProcessBuilder(const ParametersList& params, bool load_library = true)
+        : ProcessBuilder(params, load_library) {
+      setCentral(mg5_proc_->centralSystem());
+    }
+
+    proc::ProcessPtr clone() const override { return std::make_unique<GeneralProcessBuilder>(parameters(), false); }
+
+    void prepareFactorisedPhaseSpace() override {
+      if (const auto psgen_partons = phase_space_generator_->partons();
+          mg5_proc_->intermediatePartons() != psgen_partons)
+        throw CG_FATAL("mg5amc:GeneralProcessBuilder")
+            << "MadGraph unpacked process incoming state (" << mg5_proc_->intermediatePartons() << ") "
+            << "is incompatible with user-steered incoming fluxes particles (" << psgen_partons << ").";
+      if (const auto params_card = steer<std::string>("parametersCard"); !params_card.empty()) {
+        CG_INFO("mg5amc:GeneralProcessBuilder")
+            << "Preparing process kinematics for card at \"" << params_card << "\".";
+        const auto unsteered_pcard = Interface::extractParamCardParameters(utils::readFile(params_card));
+        CG_DEBUG("mg5amc:GeneralProcessBuilder") << "Unsteered parameters card:\n" << unsteered_pcard;
+        if (const auto mod_params = steer<ParametersList>("modelParameters"); !mod_params.empty()) {
+          const auto steered_pcard = unsteered_pcard.steer(mod_params);
+          CG_DEBUG("mg5amc:GeneralProcessBuilder") << "User-steered parameters:" << mod_params << "\n"
+                                                   << "Steered parameters card:\n"
+                                                   << steered_pcard;
+          std::ofstream params_card_steered(params_card);
+          params_card_steered << Interface::generateParamCard(steered_pcard);
+          params_card_steered.close();
+        }
+        mg5_proc_->initialise(params_card);
+      }
+    }
+    double computeFactorisedMatrixElement() override {
+      if (!mg5_proc_)
+        CG_FATAL("mg5amc:GeneralProcessBuilder:eval") << "Process not properly linked!";
+      if (!kinematics().cuts().initial.contain(event()(Particle::Role::Parton1)) ||
+          !kinematics().cuts().initial.contain(event()(Particle::Role::Parton2)))
+        return 0.;
+      if (!kinematics().cuts().central.contain(event()(Particle::Role::CentralSystem)))
+        return 0.;
+
+      CG_DEBUG_LOOP("mg5amc:GeneralProcessBuilder:eval")
+          << "Particles content:\n"
+          << "incoming: " << q1() << " (m=" << q1().mass() << "), " << q2() << " (m=" << q2().mass() << ")\n"
+          << "outgoing: " << pc(0) << " (m=" << pc(0).mass() << "), " << pc(1) << " (m=" << pc(1).mass() << ").";
+      mg5_proc_->setMomentum(0, q1());   // first incoming parton
+      mg5_proc_->setMomentum(1, q2());   // second incoming parton
+      mg5_proc_->setMomentum(2, pc(0));  // first outgoing central particle
+      mg5_proc_->setMomentum(3, pc(1));  // second outgoing central particle
+      if (const auto weight = mg5_proc_->eval(); utils::positive(weight))
+        return weight * std::pow(shat(), -2);
+      return 0.;
+    }
+  };
+}  // namespace cepgen::mg5amc
+using MadGraphGeneralProcessBuilder = mg5amc::GeneralProcessBuilder;
+REGISTER_PROCESS("mg5_aMC", MadGraphGeneralProcessBuilder);

--- a/addons/MadGraphWrapper/src/GeneralProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/GeneralProcessBuilder.cpp
@@ -16,8 +16,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <fstream>
-
 #include "CepGen/Core/Exception.h"
 #include "CepGen/Event/Event.h"
 #include "CepGen/Generator.h"
@@ -25,12 +23,8 @@
 #include "CepGen/Process/FactorisedProcess.h"
 #include "CepGen/Utils/Math.h"
 #include "CepGen/Utils/RandomGenerator.h"
-#include "CepGenMadGraph/Interface.h"
 #include "CepGenMadGraph/Process.h"
 #include "CepGenMadGraph/ProcessBuilder.h"
-
-using namespace cepgen;
-using namespace std::string_literals;
 
 namespace cepgen::mg5amc {
   class GeneralProcessBuilder final : public ProcessBuilder {
@@ -48,22 +42,7 @@ namespace cepgen::mg5amc {
         throw CG_FATAL("mg5amc:GeneralProcessBuilder")
             << "MadGraph unpacked process incoming state (" << mg5_proc_->intermediatePartons() << ") "
             << "is incompatible with user-steered incoming fluxes particles (" << psgen_partons << ").";
-      if (const auto params_card = steer<std::string>("parametersCard"); !params_card.empty()) {
-        CG_INFO("mg5amc:GeneralProcessBuilder")
-            << "Preparing process kinematics for card at \"" << params_card << "\".";
-        const auto unsteered_pcard = Interface::extractParamCardParameters(utils::readFile(params_card));
-        CG_DEBUG("mg5amc:GeneralProcessBuilder") << "Unsteered parameters card:\n" << unsteered_pcard;
-        if (const auto mod_params = steer<ParametersList>("modelParameters"); !mod_params.empty()) {
-          const auto steered_pcard = unsteered_pcard.steer(mod_params);
-          CG_DEBUG("mg5amc:GeneralProcessBuilder") << "User-steered parameters:" << mod_params << "\n"
-                                                   << "Steered parameters card:\n"
-                                                   << steered_pcard;
-          std::ofstream params_card_steered(params_card);
-          params_card_steered << Interface::generateParamCard(steered_pcard);
-          params_card_steered.close();
-        }
-        mg5_proc_->initialise(params_card);
-      }
+      prepareSteeringCard();
     }
     double computeFactorisedMatrixElement() override {
       if (!mg5_proc_)
@@ -88,5 +67,5 @@ namespace cepgen::mg5amc {
     }
   };
 }  // namespace cepgen::mg5amc
-using MadGraphGeneralProcessBuilder = mg5amc::GeneralProcessBuilder;
+using MadGraphGeneralProcessBuilder = cepgen::mg5amc::GeneralProcessBuilder;
 REGISTER_PROCESS("mg5_aMC", MadGraphGeneralProcessBuilder);

--- a/addons/MadGraphWrapper/src/ProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ProcessBuilder.cpp
@@ -95,3 +95,9 @@ void ProcessBuilder::prepareSteeringCard() const {
     mg5_proc_->initialise(params_card);
   }
 }
+
+mg5amc::Process& ProcessBuilder::process() const {
+  if (!mg5_proc_)
+    CG_FATAL("mg5amc:GeneralProcessBuilder:eval") << "Process not properly linked!";
+  return *mg5_proc_;
+}

--- a/addons/MadGraphWrapper/src/ProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ProcessBuilder.cpp
@@ -35,7 +35,7 @@ using namespace cepgen::mg5amc;
 using namespace std::string_literals;
 
 ProcessBuilder::ProcessBuilder(const ParametersList& params, bool load_library)
-    : FactorisedProcess(params, {}), library_filename_(steer<std::string>("lib")) {
+    : FactorisedProcess(params), library_filename_(steer<std::string>("lib")) {
   if (load_library)
     loadMG5Library();
   CG_DEBUG("mg5amc:ProcessBuilder") << "List of MadGraph process registered in the runtime database: "
@@ -48,8 +48,8 @@ ProcessBuilder::ProcessBuilder(const ParametersList& params, bool load_library)
 }
 
 ProcessBuilder::~ProcessBuilder() {
-  delete mg5_proc_.release();
-  if (!unloadLibrary(library_filename_))
+  mg5_proc_.reset();  // call the destructor, as the library will be invalidated
+  if (!library_filename_.empty() && !unloadLibrary(library_filename_))
     CG_ERROR("mg5amc:~ProcessBuilder") << "Failed to unload library '" << library_filename_ << "'.";
   if (steer<bool>("removeLibrary")) {
     std::error_code error_code;

--- a/addons/MadGraphWrapper/src/ProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ProcessBuilder.cpp
@@ -1,6 +1,6 @@
 /*
  *  CepGen: a central exclusive processes event generator
- *  Copyright (C) 2020-2025  Laurent Forthomme
+ *  Copyright (C) 2025  Laurent Forthomme
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,120 +19,61 @@
 #include <fstream>
 
 #include "CepGen/Core/Exception.h"
-#include "CepGen/Event/Event.h"
 #include "CepGen/Generator.h"
-#include "CepGen/Modules/ProcessFactory.h"
 #include "CepGen/Physics/PDG.h"
 #include "CepGen/Process/FactorisedProcess.h"
 #include "CepGen/Utils/AbortHandler.h"
-#include "CepGen/Utils/Math.h"
 #include "CepGen/Utils/RandomGenerator.h"
 #include "CepGenMadGraph/Interface.h"
 #include "CepGenMadGraph/Process.h"
+#include "CepGenMadGraph/ProcessBuilder.h"
 #include "CepGenMadGraph/ProcessFactory.h"
 #include "CepGenMadGraph/Utils.h"
 
 using namespace cepgen;
+using namespace cepgen::mg5amc;
 using namespace std::string_literals;
 
-namespace cepgen::mg5amc {
-  class ProcessBuilder final : public proc::FactorisedProcess {
-  public:
-    explicit ProcessBuilder(const ParametersList& params, bool load_library = true) : FactorisedProcess(params) {
-      if (load_library)
-        loadMG5Library();
-      CG_DEBUG("mg5amc:ProcessBuilder") << "List of MadGraph process registered in the runtime database: "
-                                        << ProcessFactory::get().modules() << ".";
-      // once MadGraph process library is loaded into runtime environment, can define its wrapper object
-      mg5_proc_ = ProcessFactory::get().build(normalise(steer<std::string>("process")));
-      if (const auto& central_system = mg5_proc_->centralSystem(); !central_system.empty())
-        setCentral(mg5_proc_->centralSystem());
-      else
-        throw CG_FATAL("mg5amc:ProcessBuilder")
-            << "Failed to retrieve produced particles system from MadGraph process:\n"
-            << mg5_proc_->description().validate(mg5_proc_->parameters()) << ".";
+ProcessBuilder::ProcessBuilder(const ParametersList& params, bool load_library) : FactorisedProcess(params, {}) {
+  if (load_library)
+    loadMG5Library();
+  CG_DEBUG("ProcessBuilder") << "List of MadGraph process registered in the runtime database: "
+                             << ProcessFactory::get().modules() << ".";
+  // once MadGraph process library is loaded into runtime environment, can define its wrapper object
+  mg5_proc_ = ProcessFactory::get().build(normalise(steer<std::string>("process")));
+  if (mg5_proc_->centralSystem().empty())
+    throw CG_FATAL("ProcessBuilder") << "Failed to retrieve produced particles system from MadGraph process:\n"
+                                     << mg5_proc_->description().validate(mg5_proc_->parameters()) << ".";
+}
+
+void ProcessBuilder::addEventContent() {
+  const auto central_system = phase_space_generator_->central();
+  setEventContent({{Particle::Role::IncomingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
+                   {Particle::Role::IncomingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
+                   {Particle::Role::OutgoingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
+                   {Particle::Role::OutgoingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
+                   {Particle::Role::CentralSystem, spdgids_t(central_system.begin(), central_system.end())}});
+}
+
+ParametersDescription ProcessBuilder::description() {
+  auto desc = FactorisedProcess::description();
+  desc.setDescription("MadGraph_aMC process builder");
+  desc.add("lib", ""s).setDescription("Precompiled library for this process definition");
+  desc.add("parametersCard", "param_card.dat"s).setDescription("Runtime MadGraph parameters card");
+  desc += Interface::description();
+  return desc;
+}
+
+void ProcessBuilder::loadMG5Library() const {
+  utils::AbortHandler();
+  try {
+    if (const auto& lib_file = steer<std::string>("lib"); !lib_file.empty())  // user-provided library file
+      loadLibrary(lib_file);
+    else {  // library has to be generated from mg5_aMC directives
+      const Interface interface(params_);
+      loadLibrary(interface.run());
     }
-
-    proc::ProcessPtr clone() const override { return std::make_unique<ProcessBuilder>(parameters(), false); }
-
-    void addEventContent() override {
-      setEventContent({{Particle::Role::IncomingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
-                       {Particle::Role::IncomingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
-                       {Particle::Role::OutgoingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
-                       {Particle::Role::OutgoingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
-                       {Particle::Role::CentralSystem, mg5_proc_->centralSystem()}});
-    }
-
-    static ParametersDescription description() {
-      auto desc = FactorisedProcess::description();
-      desc.setDescription("MadGraph_aMC process builder");
-      desc.add("lib", ""s).setDescription("Precompiled library for this process definition");
-      desc.add("parametersCard", "param_card.dat"s).setDescription("Runtime MadGraph parameters card");
-      desc += Interface::description();
-      return desc;
-    }
-
-    void prepareFactorisedPhaseSpace() override {
-      if (const auto psgen_partons = phase_space_generator_->partons();
-          mg5_proc_->intermediatePartons() != psgen_partons)
-        throw CG_FATAL("mg5amc:ProcessBuilder")
-            << "MadGraph unpacked process incoming state (" << mg5_proc_->intermediatePartons() << ") "
-            << "is incompatible with user-steered incoming fluxes particles (" << psgen_partons << ").";
-      if (const auto params_card = steer<std::string>("parametersCard"); !params_card.empty()) {
-        CG_INFO("mg5amc:ProcessBuilder") << "Preparing process kinematics for card at \"" << params_card << "\".";
-        const auto unsteered_pcard = Interface::extractParamCardParameters(utils::readFile(params_card));
-        CG_DEBUG("mg5amc:ProcessBuilder") << "Unsteered parameters card:\n" << unsteered_pcard;
-        if (const auto mod_params = steer<ParametersList>("modelParameters"); !mod_params.empty()) {
-          const auto steered_pcard = unsteered_pcard.steer(mod_params);
-          CG_DEBUG("mg5amc:ProcessBuilder") << "User-steered parameters:" << mod_params << "\n"
-                                            << "Steered parameters card:\n"
-                                            << steered_pcard;
-          std::ofstream params_card_steered(params_card);
-          params_card_steered << Interface::generateParamCard(steered_pcard);
-          params_card_steered.close();
-        }
-        mg5_proc_->initialise(params_card);
-      }
-    }
-    double computeFactorisedMatrixElement() override {
-      if (!mg5_proc_)
-        CG_FATAL("mg5amc:ProcessBuilder:eval") << "Process not properly linked!";
-      if (!kinematics().cuts().initial.contain(event()(Particle::Role::Parton1)) ||
-          !kinematics().cuts().initial.contain(event()(Particle::Role::Parton2)))
-        return 0.;
-      if (!kinematics().cuts().central.contain(event()(Particle::Role::CentralSystem)))
-        return 0.;
-
-      CG_DEBUG_LOOP("mg5amc:ProcessBuilder:eval")
-          << "Particles content:\n"
-          << "incoming: " << q1() << " (m=" << q1().mass() << "), " << q2() << " (m=" << q2().mass() << ")\n"
-          << "outgoing: " << pc(0) << " (m=" << pc(0).mass() << "), " << pc(1) << " (m=" << pc(1).mass() << ").";
-      mg5_proc_->setMomentum(0, q1());   // first incoming parton
-      mg5_proc_->setMomentum(1, q2());   // second incoming parton
-      mg5_proc_->setMomentum(2, pc(0));  // first outgoing central particle
-      mg5_proc_->setMomentum(3, pc(1));  // second outgoing central particle
-      if (const auto weight = mg5_proc_->eval(); utils::positive(weight))
-        return weight * std::pow(shat(), -2);
-      return 0.;
-    }
-
-  private:
-    void loadMG5Library() const {
-      utils::AbortHandler();
-      try {
-        if (const auto& lib_file = steer<std::string>("lib"); !lib_file.empty())  // user-provided shared library
-          loadLibrary(lib_file);
-        else {  // library must be generated from mg5_aMC directives
-          const Interface interface(params_);
-          loadLibrary(interface.run());
-        }
-      } catch (const utils::RunAbortedException&) {
-        CG_FATAL("mg5amc:ProcessBuilder") << "MadGraph_aMC process generation aborted.";
-      }
-    }
-
-    std::unique_ptr<mg5amc::Process> mg5_proc_;
-  };
-}  // namespace cepgen::mg5amc
-using MadGraphProcessBuilder = mg5amc::ProcessBuilder;
-REGISTER_PROCESS("mg5_aMC", MadGraphProcessBuilder);
+  } catch (const utils::RunAbortedException&) {
+    CG_FATAL("ProcessBuilder") << "MadGraph_aMC process generation aborted.";
+  }
+}

--- a/addons/MadGraphWrapper/src/ProcessBuilder.cpp
+++ b/addons/MadGraphWrapper/src/ProcessBuilder.cpp
@@ -46,15 +46,6 @@ ProcessBuilder::ProcessBuilder(const ParametersList& params, bool load_library) 
                                             << mg5_proc_->description().validate(mg5_proc_->parameters()) << ".";
 }
 
-void ProcessBuilder::addEventContent() {
-  const auto central_system = phase_space_generator_->central();
-  setEventContent({{Particle::Role::IncomingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
-                   {Particle::Role::IncomingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
-                   {Particle::Role::OutgoingBeam1, {kinematics().incomingBeams().positive().integerPdgId()}},
-                   {Particle::Role::OutgoingBeam2, {kinematics().incomingBeams().negative().integerPdgId()}},
-                   {Particle::Role::CentralSystem, spdgids_t(central_system.begin(), central_system.end())}});
-}
-
 ParametersDescription ProcessBuilder::description() {
   auto desc = FactorisedProcess::description();
   desc.setDescription("MadGraph_aMC process builder");

--- a/addons/MadGraphWrapper/src/Utils.cpp
+++ b/addons/MadGraphWrapper/src/Utils.cpp
@@ -177,8 +177,14 @@ namespace cepgen::mg5amc {
   }
 
   std::string normalise(const std::string& process_name, const std::string& physics_model) {
-    return (!physics_model.empty() ? physics_model + "__" : "") +
-           utils::replaceAll(process_name,
-                             {{" ", "_"}, {">", "_to_"}, {"+", "p"}, {"-", "m"}, {"~", "bar"}, {"/", "_exc_"}});
+    return (physics_model.empty() ? ""s : physics_model + "__") + utils::replaceAll(process_name,
+                                                                                    {{" ", "_"},
+                                                                                     {">", "_to_"},
+                                                                                     {"+", "p"},
+                                                                                     {"-", "m"},
+                                                                                     {"~", "bar"},
+                                                                                     {"/", "_exc_"},
+                                                                                     {"$", "_excs_"},
+                                                                                     {"|", "_or_"}});
   }
 }  // namespace cepgen::mg5amc

--- a/test/physics/process_builder.cc
+++ b/test/physics/process_builder.cc
@@ -40,10 +40,13 @@ int main(int argc, char* argv[]) {
   CG_LOG << "Will test process(es): " << processes << ".";
   for (const auto& proc_name : processes) {
     auto proc_name_fix = proc_name;
-    if (proc_name == "mg5_aMC") {
+    if (const auto mg5_proc = cepgen::utils::split(proc_name, ':'); mg5_proc.at(0) == "mg5_aMC") {
       if (!include_mg5_proc)
         continue;
-      proc_name_fix += "<process:'a a > mu- mu+'";
+      if (mg5_proc.size() > 1)
+        proc_name_fix += "<process:'a e- > mu- mu+ e-'<removeLibrary:true";
+      else
+        proc_name_fix += "<process:'a a > mu- mu+'<removeLibrary:true";
     }
     auto proc = cepgen::ProcessFactory::get().build(proc_name_fix);
     proc->initialise();


### PR DESCRIPTION
This PR introduces a new "mg5_aMC@NLO process" definition enabling to compute the electron-parton-level matrix element, and allow the first handling of beam polarisation effects.

It requires an extra care in the process string parameter, as some extra allowed exchanges can be added in and contribute to the total cross-section.