### PR TITLE
Allows runtime environment to unload libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,10 @@ jobs:
         path: validation-environment.tar.gz
 
   skimming:
-    needs: build
+    needs:
+      - test
+      - validation
+      - benchmark
     runs-on: ubuntu-latest
     container:
       image: 'laufor/ci-images:cepgen-fedora40'

--- a/CepGen/Generator.h
+++ b/CepGen/Generator.h
@@ -17,6 +17,7 @@
 #define CepGen_Generator_h
 
 #include <functional>
+#include <map>
 #include <memory>
 
 #include "CepGen/Utils/Value.h"
@@ -33,12 +34,13 @@ namespace cepgen::proc {
 }
 
 namespace cepgen {
-  static std::vector<std::string> loaded_libraries;   ///< Collection of libraries loaded in RTE
-  static std::vector<std::string> invalid_libraries;  ///< Collection of libraries tested not to work with RTE
-  static std::vector<std::string> search_paths;       ///< Collection of search paths to build RTE
+  static std::map<std::string, void*> loaded_libraries;  ///< Collection of libraries loaded in RTE
+  static std::vector<std::string> invalid_libraries;     ///< Collection of libraries tested not to work with RTE
+  static std::vector<std::string> search_paths;          ///< Collection of search paths to build RTE
   /// Execute an action on a path if found in search paths collection
-  bool callPath(const std::string&, bool (*callback)(const std::string&));
-  bool loadLibrary(const std::string&, bool match = false);  ///< Import a shared library in RTE
+  bool callPath(const std::string&, const std::function<bool(const std::string&)>&);
+  bool loadLibrary(const std::string&, bbool (*callback)(const std::string&));
+  bool unloadLibrary(const std::string&, bool match = false);  ///< Unload a shared library from RTE
   /// Launch the initialisation procedure
   /// \param[in] safe_mode Drop libraries initialisation?
   void initialise(bool safe_mode = false);

--- a/CepGen/Generator.h
+++ b/CepGen/Generator.h
@@ -39,7 +39,7 @@ namespace cepgen {
   static std::vector<std::string> search_paths;          ///< Collection of search paths to build RTE
   /// Execute an action on a path if found in search paths collection
   bool callPath(const std::string&, const std::function<bool(const std::string&)>&);
-  bool loadLibrary(const std::string&, bbool (*callback)(const std::string&));
+  bool loadLibrary(const std::string&, bool match = false);    ///< Import a shared library in RTE
   bool unloadLibrary(const std::string&, bool match = false);  ///< Unload a shared library from RTE
   /// Launch the initialisation procedure
   /// \param[in] safe_mode Drop libraries initialisation?

--- a/src/Core/GlobalFunctions.cpp
+++ b/src/Core/GlobalFunctions.cpp
@@ -114,13 +114,13 @@ namespace cepgen {
     return false;
   }
 
-  bool callPath(const std::string& local_path, bool (*callback)(const std::string&)) {
+  bool callPath(const std::string& local_path, const std::function<bool(const std::string&)>& callback) {
     if (search_paths.empty()) {
       CG_WARNING("callPath") << "List of search paths is empty.";
       return false;
     }
     for (const auto& search_path : search_paths)
-      if (const auto the_path = fs::path{search_path} / local_path; utils::fileExists(the_path))
+      if (const auto the_path = fs::path{search_path} / local_path; utils::fileExists(the_path) && callback)
         return callback(the_path);
     return false;
   }

--- a/src/Core/GlobalFunctions.cpp
+++ b/src/Core/GlobalFunctions.cpp
@@ -167,9 +167,14 @@ namespace cepgen {
     CG_INFO("init").log([&](auto& log) {
       log << "CepGen " << version::tag << " (" << version::extended << ") "
           << "initialised";
-      if (!loaded_libraries.empty())
-        log << " with " << utils::s("add-on", loaded_libraries.size(), true) << ":\n\t" << loaded_libraries << ".\n\t";
-      else
+      if (!loaded_libraries.empty()) {
+        std::vector<std::string> libraries;
+        std::transform(
+            loaded_libraries.begin(), loaded_libraries.end(), std::back_inserter(libraries), [](const auto& library) {
+              return library.first;
+            });
+        log << " with " << utils::s("add-on", loaded_libraries.size(), true) << ":\n\t" << libraries << ".\n\t";
+      } else
         log << ". ";
       log << "Greetings!";
     });

--- a/src/Core/GlobalFunctions.cpp
+++ b/src/Core/GlobalFunctions.cpp
@@ -39,38 +39,78 @@ namespace cepgen::utils {
 }
 
 namespace cepgen {
-  bool loadLibrary(const std::string& path, bool match) {
-    if (utils::contains(loaded_libraries, path))
-      return true;
+  static const auto os_independent_path = [](const std::string& path, bool match) -> std::string {
 #ifdef _WIN32
-    const auto full_path = match ? path + ".dll" : path;
+    return match ? path + ".dll" : path;
 #elif defined(__APPLE__)
-    const auto full_path = match ? "lib" + path + ".dylib" : path;
+    return match ? "lib" + path + ".dylib" : path;
 #else
-    const auto full_path = match ? "lib" + path + ".so" : path;
+    return match ? "lib" + path + ".so" : path;
 #endif
-    if (callPath(full_path, [](const auto& file_path) {
+  };
+
+  bool loadLibrary(const std::string& path, bool match) {
+    const auto full_path = os_independent_path(path, match);
+    if (loaded_libraries.count(full_path) > 0)  // library is already loaded
+      return true;
+    if (callPath(full_path, [&full_path](const auto& file_path) -> bool {
 #ifdef _WIN32
-          if (LoadLibraryA(file_path.c_str()) != nullptr)
+          if (auto* handle = LoadLibraryA(file_path.c_str()); handle != nullptr) {
+            loaded_libraries.insert(std::make_pair(full_path, handle));
             return true;
-          CG_WARNING("loadLibrary") << "Failed to load library \"" << file_path << "\".\n\t"
+          }
+          CG_WARNING("loadLibrary") << "Failed to load library '" << file_path << "'.\n\t"
                                     << "Error code #" << GetLastError() << ".";
           return false;
 #else
-          if (::dlopen(file_path.c_str(), RTLD_LAZY | RTLD_GLOBAL) != nullptr)
+          if (auto* handle = ::dlopen(file_path.c_str(), RTLD_LAZY | RTLD_GLOBAL); handle != nullptr) {
+            loaded_libraries.insert(std::make_pair(full_path, handle));
             return true;
-          const char* err = dlerror();
-          CG_WARNING("loadLibrary") << "Failed to load library " << file_path << "."
+          }
+          const char* err = ::dlerror();
+          CG_WARNING("loadLibrary") << "Failed to load library '" << file_path << "'."
                                     << (err != nullptr ? utils::format("\n\t%s", err) : "");
           return false;
 #endif
         })) {
       CG_DEBUG("loadLibrary") << "Loaded library \"" << path << "\".";
-      loaded_libraries.emplace_back(path);
       return true;
     }
     invalid_libraries.emplace_back(path);
     CG_DEBUG("loadLibrary") << "Library \"" << path << "\" (" << full_path << ") does not exist.";
+    return false;
+  }
+
+  bool unloadLibrary(const std::string& path, bool match) {
+    const auto full_path = os_independent_path(path, match);
+    if (loaded_libraries.count(full_path) == 0) {  // library is not loaded
+      CG_WARNING("unloadLibrary") << "Requested to remove library '" << full_path
+                                  << "' from runtime environment, while it was not loaded. Libraries loaded:\n"
+                                  << loaded_libraries << ".";
+      return true;
+    }
+#ifdef _WIN32
+    if (FreeLibrary(loaded_libraries.at(full_path))) {
+      loaded_libraries.erase(full_path);
+      CG_DEBUG("unloadLibrary") << "Successfully unloaded library '" << full_path
+                                << "' from runtime environment. Remaining libraries loaded:\n"
+                                << loaded_libraries << ".";
+      return true;
+    }
+    CG_WARNING("unloadLibrary") << "Failed to unload library '" << full_path << "'.\n\t"
+                                << "Error code #" << GetLastError() << ".";
+#else
+    if (const auto ret = ::dlclose(loaded_libraries.at(full_path)); ret == 0) {
+      loaded_libraries.erase(full_path);
+      CG_DEBUG("unloadLibrary") << "Successfully unloaded library '" << full_path
+                                << "' from runtime environment. Remaining libraries loaded:\n"
+                                << loaded_libraries << ".";
+      return true;
+    }
+    const char* err = ::dlerror();
+    CG_WARNING("unloadLibrary") << "Failed to unload library '" << full_path << "'."
+                                << (err != nullptr ? utils::format("\n\t%s", err) : "");
+#endif
     return false;
   }
 


### PR DESCRIPTION
This PR introduces a long-awaited procedure to unload libraries loaded in the runtime environment. This is most useful in the case several occurrences of a modified library are required to be loaded/unloaded sequentially, e.g. for MadGraph5_aMC@NLO processes tests.